### PR TITLE
Changing update for 2.5 to point to 3.3.0 instead 3.2.4

### DIFF
--- a/www/core/sts/extension_sts.xml
+++ b/www/core/sts/extension_sts.xml
@@ -70,24 +70,6 @@
 		<maintainer>Joomla! PLT</maintainer>
 		<maintainerurl>http://www.joomla.org</maintainerurl>
 		<section>STS</section>
-		<targetplatform name="joomla" version="2.5" />
-	</update>
-	<update>
-		<name>Joomla! 3.2</name>
-		<description>Joomla! CMS</description>
-		<element>joomla</element>
-		<type>file</type>
-		<version>3.2.4</version>
-		<infourl title="Joomla!">http://www.joomla.org/</infourl>
-		<downloads>
-			<downloadurl type="full" format="zip">http://joomlacode.org/gf/download/frsrelease/19392/158828/Joomla_3.2.4-Stable-Update_Package.zip</downloadurl>
-		</downloads>
-		<tags>
-			<tag>stable</tag>
-		</tags>
-		<maintainer>Joomla! PLT</maintainer>
-		<maintainerurl>http://www.joomla.org</maintainerurl>
-		<section>STS</section>
 		<targetplatform name="joomla" version="3.0"/>
 	</update>
 	<update>
@@ -161,6 +143,25 @@
 		<maintainerurl>http://www.joomla.org</maintainerurl>
 		<section>STS</section>
 		<targetplatform name="joomla" version="3.2" min_dev_level="3" />
+	</update>
+	<update>
+		<name>Joomla! 3.3</name>
+		<description>Joomla! 3.3 CMS</description>
+		<element>joomla</element>
+		<type>file</type>
+		<version>3.3.0</version>
+		<infourl title="Joomla!">http://www.joomla.org/</infourl>
+		<downloads>
+			<downloadurl type="full" format="zip">http://joomlacode.org/gf/download/frsrelease/19394/158837/Joomla_3.3.0-Stable-Update_Package.zip</downloadurl>
+		</downloads>
+		<tags>
+			<tag>stable</tag>
+		</tags>
+		<maintainer>Joomla! PLT</maintainer>
+		<maintainerurl>http://www.joomla.org</maintainerurl>
+		<section>STS</section>
+		<targetplatform name="joomla" version="2.5" />
+		<php_minimum>5.3.10</php_minimum>
 	</update>
 	<update>
 		<name>Joomla! 3.3</name>


### PR DESCRIPTION
### Issue

In Joomla 2.5 when you set the updater to STS, you will see the update package for 3.2.4 instead of 3.3.0.
The current update stream indeed marks the 3.2.4 update with `<targetplatform name="joomla" version="2.5" />` instead of the one for 3.3.0.
### Tracker

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33709
### Solution

Diff looks funny. I have changed 

```
<update>
    <name>Joomla! 3.2</name>
    <description>Joomla! CMS</description>
    <element>joomla</element>
    <type>file</type>
    <version>3.2.4</version>
    <infourl title="Joomla!">http://www.joomla.org/</infourl>
    <downloads>
        <downloadurl type="full" format="zip">http://joomlacode.org/gf/download/frsrelease/19392/158828/Joomla_3.2.4-Stable-Update_Package.zip</downloadurl>
    </downloads>
    <tags>
        <tag>stable</tag>
    </tags>
    <maintainer>Joomla! PLT</maintainer>
    <maintainerurl>http://www.joomla.org</maintainerurl>
    <section>STS</section>
    <targetplatform name="joomla" version="2.5" />
</update>
```

to

```
<update>
    <name>Joomla! 3.3</name>
    <description>Joomla! 3.3 CMS</description>
    <element>joomla</element>
    <type>file</type>
    <version>3.3.0</version>
    <infourl title="Joomla!">http://www.joomla.org/</infourl>
    <downloads>
        <downloadurl type="full" format="zip">http://joomlacode.org/gf/download/frsrelease/19394/158837/Joomla_3.3.0-Stable-Update_Package.zip</downloadurl>
    </downloads>
    <tags>
        <tag>stable</tag>
    </tags>
    <maintainer>Joomla! PLT</maintainer>
    <maintainerurl>http://www.joomla.org</maintainerurl>
    <section>STS</section>
    <targetplatform name="joomla" version="2.5" />
    <php_minimum>5.3.10</php_minimum>
</update>
```

and moved it down to the Joomla! 3.3 updates

Unfortunately I can't test it, so it's a bit of a shoot into the dark.
