### PR TITLE
Switch joomla.org and update.joomla.org to https

### DIFF
--- a/www/core/extension.xml
+++ b/www/core/extension.xml
@@ -6,7 +6,7 @@
 		<element>joomla</element>
 		<type>file</type>
 		<version>1.7.0</version>
-		<infourl title="Joomla!">http://www.joomla.org/</infourl>
+		<infourl title="Joomla!">https://www.joomla.org/</infourl>
 		<downloads>
 			<downloadurl type="full" format="zip">http://joomlacode.org/gf/download/frsrelease/15901/68959/Joomla_1.6.x_to_1.7.0_Package.zip</downloadurl>
 		</downloads>
@@ -14,7 +14,7 @@
 			<tag>stable</tag>
 		</tags>
 		<maintainer>Joomla! PLT</maintainer>
-		<maintainerurl>http://www.joomla.org</maintainerurl>
+		<maintainerurl>https://www.joomla.org</maintainerurl>
 		<section>LTS</section>
 		<targetplatform name="joomla" version="1.6" />
 	</update>
@@ -24,7 +24,7 @@
 		<element>joomla</element>
 		<type>file</type>
 		<version>2.5.28</version>
-		<infourl title="Joomla!">http://www.joomla.org/announcements/release-news/5574-joomla-2-5-28-released.html</infourl>
+		<infourl title="Joomla!">https://www.joomla.org/announcements/release-news/5574-joomla-2-5-28-released.html</infourl>
 		<downloads>
 			<downloadurl type="full" format="zip">http://joomlacode.org/gf/download/frsrelease/19919/161810/Joomla_2.5.28-Stable-Update_Package.zip</downloadurl>
 		</downloads>
@@ -32,7 +32,7 @@
 			<tag>stable</tag>
 		</tags>
 		<maintainer>Joomla! PLT</maintainer>
-		<maintainerurl>http://www.joomla.org</maintainerurl>
+		<maintainerurl>https://www.joomla.org</maintainerurl>
 		<section>LTS</section>
 		<targetplatform name="joomla" version="1.7" />
 	</update>
@@ -42,7 +42,7 @@
 		<element>joomla</element>
 		<type>file</type>
 		<version>2.5.28</version>
-		<infourl title="Joomla!">http://www.joomla.org/announcements/release-news/5574-joomla-2-5-28-released.html</infourl>
+		<infourl title="Joomla!">https://www.joomla.org/announcements/release-news/5574-joomla-2-5-28-released.html</infourl>
 		<downloads>
 			<downloadurl type="full" format="zip">http://joomlacode.org/gf/download/frsrelease/19919/161809/Joomla_2.5.x_to_2.5.28-Stable-Patch_Package.zip</downloadurl>
 		</downloads>
@@ -50,7 +50,7 @@
 			<tag>stable</tag>
 		</tags>
 		<maintainer>Joomla! PLT</maintainer>
-		<maintainerurl>http://www.joomla.org</maintainerurl>
+		<maintainerurl>https://www.joomla.org</maintainerurl>
 		<section>LTS</section>
 		<targetplatform name="joomla" version="2.5" />
 	</update>

--- a/www/core/list.xml
+++ b/www/core/list.xml
@@ -1,10 +1,10 @@
 <extensionset name="Joomla Core" description="Joomla! Core">
-	<extension name="Joomla" element="joomla" type="file" version="2.5.28" targetplatformversion="2.5" detailsurl="http://update.joomla.org/core/extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="3.1.3" targetplatformversion="3.1.2" detailsurl="http://update.joomla.org/core/sts/extension_sts.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="3.2.7" targetplatformversion="3.0" detailsurl="http://update.joomla.org/core/sts/extension_sts.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="3.2.7" targetplatformversion="3.1" detailsurl="http://update.joomla.org/core/sts/extension_sts.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="3.4.5" targetplatformversion="3.2" detailsurl="http://update.joomla.org/core/sts/extension_sts.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="3.2.7" targetplatformversion="3.2" detailsurl="http://update.joomla.org/core/sts/extension_sts.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="3.4.5" targetplatformversion="3.3" detailsurl="http://update.joomla.org/core/sts/extension_sts.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="3.4.5" targetplatformversion="3.4" detailsurl="http://update.joomla.org/core/sts/extension_sts.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="2.5.28" targetplatformversion="2.5" detailsurl="https://update.joomla.org/core/extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="3.1.3" targetplatformversion="3.1.2" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="3.2.7" targetplatformversion="3.0" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="3.2.7" targetplatformversion="3.1" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="3.4.5" targetplatformversion="3.2" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="3.2.7" targetplatformversion="3.2" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="3.4.5" targetplatformversion="3.3" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="3.4.5" targetplatformversion="3.4" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
 </extensionset>

--- a/www/core/sts/extension_sts.xml
+++ b/www/core/sts/extension_sts.xml
@@ -14,7 +14,7 @@
 			<tag>stable</tag>
 		</tags>
 		<maintainer>Joomla! PLT</maintainer>
-		<maintainerurl>http://www.joomla.org</maintainerurl>
+		<maintainerurl>https://www.joomla.org</maintainerurl>
 		<section>STS</section>
 		<targetplatform name="joomla" version="3.1" min_dev_level="2" max_dev_level="2"/>
 	</update>
@@ -50,7 +50,7 @@
 			<tag>stable</tag>
 		</tags>
 		<maintainer>Joomla! PLT</maintainer>
-		<maintainerurl>http://www.joomla.org</maintainerurl>
+		<maintainerurl>https://www.joomla.org</maintainerurl>
 		<section>STS</section>
 		<targetplatform name="joomla" version="3.1" min_dev_level="0" max_dev_level="1"/>
 	</update>
@@ -68,7 +68,7 @@
 			<tag>stable</tag>
 		</tags>
 		<maintainer>Joomla! PLT</maintainer>
-		<maintainerurl>http://www.joomla.org</maintainerurl>
+		<maintainerurl>https://www.joomla.org</maintainerurl>
 		<section>STS</section>
 		<targetplatform name="joomla" version="3.1" min_dev_level="3"/>
 	</update>
@@ -86,7 +86,7 @@
 			<tag>stable</tag>
 		</tags>
 		<maintainer>Joomla! PLT</maintainer>
-		<maintainerurl>http://www.joomla.org</maintainerurl>
+		<maintainerurl>https://www.joomla.org</maintainerurl>
 		<section>STS</section>
 		<targetplatform name="joomla" version="3.2" min_dev_level="0" max_dev_level="5" />
 	</update>
@@ -104,7 +104,7 @@
 			<tag>stable</tag>
 		</tags>
 		<maintainer>Joomla! PLT</maintainer>
-		<maintainerurl>http://www.joomla.org</maintainerurl>
+		<maintainerurl>https://www.joomla.org</maintainerurl>
 		<section>STS</section>
 		<targetplatform name="joomla" version="3.2" min_dev_level="6" />
 	</update>
@@ -122,7 +122,7 @@
 			<tag>stable</tag>
 		</tags>
 		<maintainer>Joomla! PLT</maintainer>
-		<maintainerurl>http://www.joomla.org</maintainerurl>
+		<maintainerurl>https://www.joomla.org</maintainerurl>
 		<section>STS</section>
 		<targetplatform name="joomla" version="2.5" />
 		<php_minimum>5.3.10</php_minimum>
@@ -141,7 +141,7 @@
 			<tag>stable</tag>
 		</tags>
 		<maintainer>Joomla! PLT</maintainer>
-		<maintainerurl>http://www.joomla.org</maintainerurl>
+		<maintainerurl>https://www.joomla.org</maintainerurl>
 		<section>STS</section>
 		<targetplatform name="joomla" version="3.2" min_dev_level="2" />
 		<php_minimum>5.3.10</php_minimum>
@@ -160,7 +160,7 @@
 			<tag>stable</tag>
 		</tags>
 		<maintainer>Joomla! PLT</maintainer>
-		<maintainerurl>http://www.joomla.org</maintainerurl>
+		<maintainerurl>https://www.joomla.org</maintainerurl>
 		<section>STS</section>
 		<targetplatform name="joomla" version="3.3" />
 		<php_minimum>5.3.10</php_minimum>
@@ -179,7 +179,7 @@
    			<tag>stable</tag>
    		</tags>
    		<maintainer>Joomla! PLT</maintainer>
-   		<maintainerurl>http://www.joomla.org</maintainerurl>
+   		<maintainerurl>https://www.joomla.org</maintainerurl>
    		<section>STS</section>
    		<targetplatform name="joomla" version="3.4" max_dev_level="3"/>
    		<php_minimum>5.3.10</php_minimum>
@@ -198,7 +198,7 @@
    			<tag>stable</tag>
    		</tags>
    		<maintainer>Joomla! PLT</maintainer>
-   		<maintainerurl>http://www.joomla.org</maintainerurl>
+   		<maintainerurl>https://www.joomla.org</maintainerurl>
    		<section>STS</section>
    		<targetplatform name="joomla" version="3.4" min_dev_level="4"/>
    		<php_minimum>5.3.10</php_minimum>

--- a/www/core/sts/list_sts.xml
+++ b/www/core/sts/list_sts.xml
@@ -1,10 +1,10 @@
 <extensionset name="Joomla Core" description="Joomla! Core">
-	<extension name="Joomla" element="joomla" type="file" version="3.1.3" targetplatformversion="3.1.2" detailsurl="http://update.joomla.org/core/sts/extension_sts.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="3.4.5" targetplatformversion="2.5" detailsurl="http://update.joomla.org/core/sts/extension_sts.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="3.2.7" targetplatformversion="3.0" detailsurl="http://update.joomla.org/core/sts/extension_sts.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="3.2.7" targetplatformversion="3.1" detailsurl="http://update.joomla.org/core/sts/extension_sts.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="3.4.4" targetplatformversion="3.2" detailsurl="http://update.joomla.org/core/sts/extension_sts.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="3.2.7" targetplatformversion="3.2" detailsurl="http://update.joomla.org/core/sts/extension_sts.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="3.4.5" targetplatformversion="3.3" detailsurl="http://update.joomla.org/core/sts/extension_sts.xml" />
- 	<extension name="Joomla" element="joomla" type="file" version="3.4.5" targetplatformversion="3.4" detailsurl="http://update.joomla.org/core/sts/extension_sts.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="3.1.3" targetplatformversion="3.1.2" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="3.4.5" targetplatformversion="2.5" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="3.2.7" targetplatformversion="3.0" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="3.2.7" targetplatformversion="3.1" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="3.4.4" targetplatformversion="3.2" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="3.2.7" targetplatformversion="3.2" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="3.4.5" targetplatformversion="3.3" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
+ 	<extension name="Joomla" element="joomla" type="file" version="3.4.5" targetplatformversion="3.4" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
 </extensionset>

--- a/www/core/test/extension_test.xml
+++ b/www/core/test/extension_test.xml
@@ -6,7 +6,7 @@
 		<element>joomla</element>
 		<type>file</type>
 		<version>2.5.28.rc2</version>
-		<infourl title="Joomla!">http://www.joomla.org/</infourl>
+		<infourl title="Joomla!">https://www.joomla.org/</infourl>
 		<downloads>
 			<downloadurl type="full" format="zip">https://github.com/joomla/joomla-cms/releases/download/2.5.28.rc/Joomla_2.5.x_to_2.5.28.rc2-Release_Candidate-Patch_Package.zip</downloadurl>
 		</downloads>

--- a/www/core/test/list_test.xml
+++ b/www/core/test/list_test.xml
@@ -1,10 +1,10 @@
 <extensionset name="Joomla Core" description="Joomla! Core">
-	<extension name="Joomla" element="joomla" type="file" version="2.5.28.rc2" targetplatformversion="2.5" detailsurl="http://update.joomla.org/core/test/extension_test.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="3.1.3" targetplatformversion="3.1.2" detailsurl="http://update.joomla.org/core/sts/extension_sts.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="3.2.7" targetplatformversion="3.0" detailsurl="http://update.joomla.org/core/sts/extension_sts.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="3.2.7" targetplatformversion="3.1" detailsurl="http://update.joomla.org/core/sts/extension_sts.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="3.5.0-beta" targetplatformversion="3.2" detailsurl="http://update.joomla.org/core/teststs/extension_sts.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="3.2.7" targetplatformversion="3.2" detailsurl="http://update.joomla.org/core/sts/extension_sts.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="3.5.0-beta" targetplatformversion="3.3" detailsurl="http://update.joomla.org/core/teststs/extension_sts.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="3.5.0-beta" targetplatformversion="3.4" detailsurl="http://update.joomla.org/core/teststs/extension_sts.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="2.5.28.rc2" targetplatformversion="2.5" detailsurl="https://update.joomla.org/core/test/extension_test.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="3.1.3" targetplatformversion="3.1.2" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="3.2.7" targetplatformversion="3.0" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="3.2.7" targetplatformversion="3.1" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="3.5.0-beta" targetplatformversion="3.2" detailsurl="https://update.joomla.org/core/teststs/extension_sts.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="3.2.7" targetplatformversion="3.2" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="3.5.0-beta" targetplatformversion="3.3" detailsurl="https://update.joomla.org/core/teststs/extension_sts.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="3.5.0-beta" targetplatformversion="3.4" detailsurl="https://update.joomla.org/core/teststs/extension_sts.xml" />
 </extensionset>

--- a/www/core/test/list_test_25to3x.xml
+++ b/www/core/test/list_test_25to3x.xml
@@ -1,4 +1,4 @@
 <extensionset name="Joomla Core" description="Joomla! Core">
-	<extension name="Joomla" element="joomla" type="file" version="3.2.3.rc" targetplatformversion="2.5" detailsurl="http://update.joomla.org/core/teststs/extension_sts.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="3.2.3.rc" targetplatformversion="2.5" detailsurl="https://update.joomla.org/core/teststs/extension_sts.xml" />
 </extensionset>
 

--- a/www/core/teststs/extension_sts.xml
+++ b/www/core/teststs/extension_sts.xml
@@ -14,7 +14,7 @@
 			<tag>stable</tag>
 		</tags>
 		<maintainer>Joomla! PLT</maintainer>
-		<maintainerurl>http://www.joomla.org</maintainerurl>
+		<maintainerurl>https://www.joomla.org</maintainerurl>
 		<section>STS</section>
 		<targetplatform name="joomla" version="3.2" min_dev_level="2" />
 		<php_minimum>5.3.10</php_minimum>
@@ -33,7 +33,7 @@
 			<tag>stable</tag>
 		</tags>
 		<maintainer>Joomla! PLT</maintainer>
-		<maintainerurl>http://www.joomla.org</maintainerurl>
+		<maintainerurl>https://www.joomla.org</maintainerurl>
 		<section>STS</section>
 		<targetplatform name="joomla" version="3.3" />
 		<php_minimum>5.3.10</php_minimum>
@@ -52,7 +52,7 @@
 			<tag>stable</tag>
 		</tags>
 		<maintainer>Joomla! PLT</maintainer>
-		<maintainerurl>http://www.joomla.org</maintainerurl>
+		<maintainerurl>https://www.joomla.org</maintainerurl>
 		<section>STS</section>
 		<targetplatform name="joomla" version="3.4" max_dev_level="3" />
 		<php_minimum>5.3.10</php_minimum>
@@ -71,7 +71,7 @@
 			<tag>stable</tag>
 		</tags>
 		<maintainer>Joomla! PLT</maintainer>
-		<maintainerurl>http://www.joomla.org</maintainerurl>
+		<maintainerurl>https://www.joomla.org</maintainerurl>
 		<section>STS</section>
 		<targetplatform name="joomla" version="3.4" min_dev_level="4" />
 		<php_minimum>5.3.10</php_minimum>

--- a/www/core/teststs/list_sts.xml
+++ b/www/core/teststs/list_sts.xml
@@ -1,9 +1,9 @@
 <extensionset name="Joomla Core" description="Joomla! Core">
-	<extension name="Joomla" element="joomla" type="file" version="3.1.3" targetplatformversion="3.1.2" detailsurl="http://update.joomla.org/core/sts/extension_sts.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="3.2.7" targetplatformversion="3.0" detailsurl="http://update.joomla.org/core/sts/extension_sts.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="3.2.7" targetplatformversion="3.1" detailsurl="http://update.joomla.org/core/sts/extension_sts.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="3.5.0-beta" targetplatformversion="3.2" detailsurl="http://update.joomla.org/core/teststs/extension_sts.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="3.2.7" targetplatformversion="3.2" detailsurl="http://update.joomla.org/core/sts/extension_sts.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="3.5.0-beta" targetplatformversion="3.3" detailsurl="http://update.joomla.org/core/teststs/extension_sts.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="3.5.0-beta" targetplatformversion="3.4" detailsurl="http://update.joomla.org/core/teststs/extension_sts.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="3.1.3" targetplatformversion="3.1.2" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="3.2.7" targetplatformversion="3.0" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="3.2.7" targetplatformversion="3.1" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="3.5.0-beta" targetplatformversion="3.2" detailsurl="https://update.joomla.org/core/teststs/extension_sts.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="3.2.7" targetplatformversion="3.2" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="3.5.0-beta" targetplatformversion="3.3" detailsurl="https://update.joomla.org/core/teststs/extension_sts.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="3.5.0-beta" targetplatformversion="3.4" detailsurl="https://update.joomla.org/core/teststs/extension_sts.xml" />
 </extensionset>


### PR DESCRIPTION
This PR just switch joomla.org and update.joomla.org links in the update stream to HTTPS.

If accepted do we need similiar changes to the translation update server and where this is to change if needed?

Feel free to close if you see any issues with it. Thanks.