### PR TITLE
The reinstall feature require a entry with targetplatformversion="3.5"

### DIFF
--- a/www/core/teststs/list_sts.xml
+++ b/www/core/teststs/list_sts.xml
@@ -6,4 +6,5 @@
 	<extension name="Joomla" element="joomla" type="file" version="3.2.7" targetplatformversion="3.2" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="3.5.0-rc4" targetplatformversion="3.3" detailsurl="https://update.joomla.org/core/teststs/extension_sts.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="3.5.0-rc4" targetplatformversion="3.4" detailsurl="https://update.joomla.org/core/teststs/extension_sts.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="3.5.0-rc4" targetplatformversion="3.5" detailsurl="https://update.joomla.org/core/teststs/extension_sts.xml" />
 </extensionset>


### PR DESCRIPTION
As found here: https://github.com/joomla/joomla-cms/pull/9612 for the reinstall feature we need a entry with targetplatformversion="3.5"