### PR TITLE
Fix Update URL (3.6 beta1)

### DIFF
--- a/www/core/teststs/extension_sts.xml
+++ b/www/core/teststs/extension_sts.xml
@@ -27,7 +27,7 @@
 		<version>3.6.0-beta1</version>
 		<infourl title="Joomla!">https://www.joomla.org/announcements/release-news/5660-joomla-3-6-beta-1-released.html</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://github.com/joomla/joomla-cms/releases/download/3.6.0-alpha/Joomla_3.6.0-beta1-Beta-Update_Package.zip</downloadurl>
+			<downloadurl type="full" format="zip">https://github.com/joomla/joomla-cms/releases/download/3.6.0-beta1/Joomla_3.6.0-beta1-Beta-Update_Package.zip</downloadurl>
 		</downloads>
 		<tags>
 			<tag>stable</tag>
@@ -35,7 +35,7 @@
 		<maintainer>Joomla! PLT</maintainer>
 		<maintainerurl>https://www.joomla.org</maintainerurl>
 		<section>STS</section>
-		<targetplatform name="joomla" version="3.[345]" />
+		<targetplatform name="joomla" version="3.[34567]" />
 		<php_minimum>5.3.10</php_minimum>
 	</update>
 </updates>


### PR DESCRIPTION
Hi @wilsonge this fixes the update URL for com_joomlaupdate

Wrong: https://github.com/joomla/joomla-cms/releases/download/3.6.0-alpha/Joomla_3.6.0-beta1-Beta-Update_Package.zip 
Correct: https://github.com/joomla/joomla-cms/releases/download/3.6.0-beta1/Joomla_3.6.0-beta1-Beta-Update_Package.zip

Thanks goes to @ufuk-avcu !