### PR TITLE
Enable the reinstall feature to all update servers

### DIFF
--- a/www/core/sts/list_sts.xml
+++ b/www/core/sts/list_sts.xml
@@ -6,6 +6,7 @@
 	<extension name="Joomla" element="joomla" type="file" version="3.6.0" targetplatformversion="3.2" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="3.2.7" targetplatformversion="3.2" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="3.6.0" targetplatformversion="3.3" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
- 	<extension name="Joomla" element="joomla" type="file" version="3.6.0" targetplatformversion="3.4" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
- 	<extension name="Joomla" element="joomla" type="file" version="3.6.0" targetplatformversion="3.5" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="3.6.0" targetplatformversion="3.4" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="3.6.0" targetplatformversion="3.5" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="3.6.0" targetplatformversion="3.6" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
 </extensionset>

--- a/www/core/test/list_test.xml
+++ b/www/core/test/list_test.xml
@@ -8,4 +8,5 @@
 	<extension name="Joomla" element="joomla" type="file" version="3.6.0" targetplatformversion="3.3" detailsurl="https://update.joomla.org/core/teststs/extension_sts.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="3.6.0" targetplatformversion="3.4" detailsurl="https://update.joomla.org/core/teststs/extension_sts.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="3.6.0" targetplatformversion="3.5" detailsurl="https://update.joomla.org/core/teststs/extension_sts.xml"/>
+	<extension name="Joomla" element="joomla" type="file" version="3.6.0" targetplatformversion="3.6" detailsurl="https://update.joomla.org/core/teststs/extension_sts.xml"/>
 </extensionset>

--- a/www/core/teststs/list_sts.xml
+++ b/www/core/teststs/list_sts.xml
@@ -7,4 +7,5 @@
 	<extension name="Joomla" element="joomla" type="file" version="3.6.0" targetplatformversion="3.3" detailsurl="https://update.joomla.org/core/teststs/extension_sts.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="3.6.0" targetplatformversion="3.4" detailsurl="https://update.joomla.org/core/teststs/extension_sts.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="3.6.0" targetplatformversion="3.5" detailsurl="https://update.joomla.org/core/teststs/extension_sts.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="3.6.0" targetplatformversion="3.6" detailsurl="https://update.joomla.org/core/teststs/extension_sts.xml" />
 </extensionset>


### PR DESCRIPTION
This PR enable the new reinstall feature for all Update Servers.

### How to test

switch to the "Joomla Next Update Server"
clear the update cache 
notice that there is no "reinstall" button

apply this patch

clear the update cache again
notice there is now the reinstall button

### Technical reason

As we did not have a `targetplatformversion="3.6"` entry in the `next` Update Server the updater can't find the update and reinstall package.