### PR TITLE
Change package URLs to the downloads site

### DIFF
--- a/www/core/extension.xml
+++ b/www/core/extension.xml
@@ -8,7 +8,7 @@
 		<version>1.7.0</version>
 		<infourl title="Joomla!">https://www.joomla.org/</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">http://joomlacode.org/gf/download/frsrelease/15901/68959/Joomla_1.6.x_to_1.7.0_Package.zip</downloadurl>
+			<downloadurl type="full" format="zip">https://downloads.joomla.org/cms/joomla25/1-7-0/joomla_1-6-x_to_1-7-0_package-zip?format=zip&amp;jcompat=my.zip</downloadurl>
 		</downloads>
 		<tags>
 			<tag>stable</tag>
@@ -26,7 +26,7 @@
 		<version>2.5.28</version>
 		<infourl title="Joomla!">https://www.joomla.org/announcements/release-news/5574-joomla-2-5-28-released.html</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">http://joomlacode.org/gf/download/frsrelease/19919/161810/Joomla_2.5.28-Stable-Update_Package.zip</downloadurl>
+			<downloadurl type="full" format="zip">https://downloads.joomla.org/cms/joomla25/2-5-28/joomla_2-5-28-stable-update_package-zip?format=zip&amp;jcompat=my.zip</downloadurl>
 		</downloads>
 		<tags>
 			<tag>stable</tag>
@@ -44,7 +44,7 @@
 		<version>2.5.28</version>
 		<infourl title="Joomla!">https://www.joomla.org/announcements/release-news/5574-joomla-2-5-28-released.html</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">http://joomlacode.org/gf/download/frsrelease/19919/161809/Joomla_2.5.x_to_2.5.28-Stable-Patch_Package.zip</downloadurl>
+			<downloadurl type="full" format="zip">https://downloads.joomla.org/cms/joomla25/2-5-28/joomla_2-5-x_to_2-5-28-stable-patch_package-zip?format=zip&amp;jcompat=my.zip</downloadurl>
 		</downloads>
 		<tags>
 			<tag>stable</tag>

--- a/www/core/sts/extension_sts.xml
+++ b/www/core/sts/extension_sts.xml
@@ -8,7 +8,7 @@
 		<version>3.1.3</version>
 		<infourl title="Joomla!">https://www.joomla.org/</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">http://joomlacode.org/gf/download/frsrelease/18552/83311/Joomla_3.1.2_to_3.1.3-Stable-Patch_Package.zip</downloadurl>
+			<downloadurl type="full" format="zip">https://downloads.joomla.org/cms/joomla3/3-1-3/joomla_3-1-2_to_3-1-3-stable-patch_package-tar-gz?format=gz&amp;jcompat=my.zip</downloadurl>
 		</downloads>
 		<tags>
 			<tag>stable</tag>
@@ -26,7 +26,7 @@
 		<version>3.2.7</version>
 		<infourl title="Joomla!">https://www.joomla.org/</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://github.com/joomla/joomla-cms/releases/download/3.2.7/Joomla_3.2.7-Stable-Update_Package.zip</downloadurl>
+			<downloadurl type="full" format="zip">https://downloads.joomla.org/cms/joomla3/3-2-7/joomla_3-2-7-stable-update_package-zip?format=zip&amp;jcompat=my.zip</downloadurl>
 		</downloads>
 		<tags>
 			<tag>stable</tag>
@@ -44,7 +44,7 @@
 		<version>3.2.7</version>
 		<infourl title="Joomla!">https://www.joomla.org/</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://github.com/joomla/joomla-cms/releases/download/3.2.7/Joomla_3.2.7-Stable-Update_Package.zip</downloadurl>
+			<downloadurl type="full" format="zip">https://downloads.joomla.org/cms/joomla3/3-2-7/joomla_3-2-7-stable-update_package-zip?format=zip&amp;jcompat=my.zip</downloadurl>
 		</downloads>
 		<tags>
 			<tag>stable</tag>
@@ -62,7 +62,7 @@
 		<version>3.2.7</version>
 		<infourl title="Joomla!">https://www.joomla.org/</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://github.com/joomla/joomla-cms/releases/download/3.2.7/Joomla_3.2.7-Stable-Update_Package.zip</downloadurl>
+			<downloadurl type="full" format="zip">https://downloads.joomla.org/cms/joomla3/3-2-7/joomla_3-2-7-stable-update_package-zip?format=zip&amp;jcompat=my.zip</downloadurl>
 		</downloads>
 		<tags>
 			<tag>stable</tag>
@@ -80,7 +80,7 @@
 		<version>3.2.7</version>
 		<infourl title="Joomla!">https://www.joomla.org/</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://github.com/joomla/joomla-cms/releases/download/3.2.7/Joomla_3.2.x_to_3.2.7-Stable-Patch_Package.zip</downloadurl>
+			<downloadurl type="full" format="zip">https://downloads.joomla.org/cms/joomla3/3-2-7/joomla_3-2-x_to_3-2-7-stable-patch_package-zip?format=zip&amp;jcompat=my.zip</downloadurl>
 		</downloads>
 		<tags>
 			<tag>stable</tag>
@@ -98,7 +98,7 @@
 		<version>3.2.7</version>
 		<infourl title="Joomla!">https://www.joomla.org/</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://github.com/joomla/joomla-cms/releases/download/3.2.7/Joomla_3.2.6_to_3.2.7-Stable-Patch_Package.zip</downloadurl>
+			<downloadurl type="full" format="zip">https://downloads.joomla.org/cms/joomla3/3-2-7/joomla_3-2-6_to_3-2-7-stable-patch_package-zip?format=zip&amp;jcompat=my.zip</downloadurl>
 		</downloads>
 		<tags>
 			<tag>stable</tag>
@@ -116,7 +116,7 @@
 		<version>3.5.1</version>
 		<infourl title="Joomla!">https://www.joomla.org/announcements/release-news/5655-joomla-3-5-1-released.html</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://github.com/joomla/joomla-cms/releases/download/3.5.1/Joomla_3.5.1-Stable-Update_Package.zip</downloadurl>
+			<downloadurl type="full" format="zip">https://downloads.joomla.org/cms/joomla3/3-5-1/joomla_3-5-1-stable-update_package-zip?format=zip&amp;jcompat=my.zip</downloadurl>
 		</downloads>
 		<tags>
 			<tag>stable</tag>
@@ -135,7 +135,7 @@
 		<version>3.6.3</version>
 		<infourl title="Joomla!">https://www.joomla.org/announcements/release-news/5676-joomla-3-6-3-released.html</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://github.com/joomla/joomla-cms/releases/download/3.6.3/Joomla_3.6.3-Stable-Update_Package.zip</downloadurl>
+			<downloadurl type="full" format="zip">https://downloads.joomla.org/cms/joomla3/3-6-3/joomla_3-6-3-stable-update_package-zip?format=zip&amp;jcompat=my.zip</downloadurl>
 		</downloads>
 		<tags>
 			<tag>stable</tag>


### PR DESCRIPTION
Changes the package URLs from GitHub to the download site.

This PR is only here to make sure I've got everything right.  I will merge it when we do the official cutover to the new site.
