### PR TITLE
3.6.4 

### DIFF
--- a/www/core/list.xml
+++ b/www/core/list.xml
@@ -3,10 +3,10 @@
 	<extension name="Joomla" element="joomla" type="file" version="3.1.3" targetplatformversion="3.1.2" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="3.2.7" targetplatformversion="3.0" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="3.2.7" targetplatformversion="3.1" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="3.6.3" targetplatformversion="3.2" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="3.6.4" targetplatformversion="3.2" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="3.2.7" targetplatformversion="3.2" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="3.6.3" targetplatformversion="3.3" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="3.6.3" targetplatformversion="3.4" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="3.6.3" targetplatformversion="3.5" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="3.6.3" targetplatformversion="3.6" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="3.6.4" targetplatformversion="3.3" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="3.6.4" targetplatformversion="3.4" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="3.6.4" targetplatformversion="3.5" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="3.6.4" targetplatformversion="3.6" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
 </extensionset>

--- a/www/core/nightlies/next_patch_extension.xml
+++ b/www/core/nightlies/next_patch_extension.xml
@@ -5,7 +5,7 @@
 		<description>Joomla! CMS</description>
 		<element>joomla</element>
 		<type>file</type>
-		<version>3.6.4-dev1</version>
+		<version>3.6.5-dev1</version>
 		<infourl title="Joomla! Nightly Builds">https://developer.joomla.org/nightly-builds.html</infourl>
 		<downloads>
 			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_3.6.4-dev-Development-Update_Package.zip</downloadurl>

--- a/www/core/nightlies/next_patch_list.xml
+++ b/www/core/nightlies/next_patch_list.xml
@@ -1,5 +1,5 @@
 <extensionset name="Joomla! Core Nightly Builds" description="Joomla! Core Next Patch Nightly Builds">
-	<extension name="Joomla" element="joomla" type="file" version="3.6.4-dev1" targetplatformversion="3.4" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="3.6.4-dev1" targetplatformversion="3.5" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="3.6.4-dev1" targetplatformversion="3.6" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="3.6.5-dev1" targetplatformversion="3.4" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="3.6.5-dev1" targetplatformversion="3.5" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="3.6.5-dev1" targetplatformversion="3.6" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
 </extensionset>

--- a/www/core/sts/extension_sts.xml
+++ b/www/core/sts/extension_sts.xml
@@ -109,8 +109,8 @@
 		<targetplatform name="joomla" version="3.2" min_dev_level="6" />
 	</update>
 	<update>
-		<name>Joomla! 3.6</name>
-		<description>Joomla! 3.6 CMS</description>
+		<name>Joomla! 3.5</name>
+		<description>Joomla! 3.5 CMS</description>
 		<element>joomla</element>
 		<type>file</type>
 		<version>3.5.1</version>

--- a/www/core/sts/extension_sts.xml
+++ b/www/core/sts/extension_sts.xml
@@ -133,7 +133,7 @@
 		<element>joomla</element>
 		<type>file</type>
 		<version>3.6.4</version>
-		<infourl title="Joomla!">https://www.joomla.org/announcements/release-news/</infourl>
+		<infourl title="Joomla!">https://www.joomla.org/announcements/release-news/5678-joomla-3-6-4-released.html</infourl>
 		<downloads>
 			<downloadurl type="full" format="zip">https://github.com/joomla/joomla-cms/releases/download/3.6.4/Joomla_3.6.4-Stable-Update_Package.zip</downloadurl>
 		</downloads>

--- a/www/core/sts/extension_sts.xml
+++ b/www/core/sts/extension_sts.xml
@@ -132,10 +132,10 @@
 		<description>Joomla! 3.6 CMS</description>
 		<element>joomla</element>
 		<type>file</type>
-		<version>3.6.3</version>
-		<infourl title="Joomla!">https://www.joomla.org/announcements/release-news/5676-joomla-3-6-3-released.html</infourl>
+		<version>3.6.4</version>
+		<infourl title="Joomla!">https://www.joomla.org/announcements/release-news/</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://github.com/joomla/joomla-cms/releases/download/3.6.3/Joomla_3.6.3-Stable-Update_Package.zip</downloadurl>
+			<downloadurl type="full" format="zip">https://github.com/joomla/joomla-cms/releases/download/3.6.4/Joomla_3.6.4-Stable-Update_Package.zip</downloadurl>
 		</downloads>
 		<tags>
 			<tag>stable</tag>

--- a/www/core/sts/list_sts.xml
+++ b/www/core/sts/list_sts.xml
@@ -3,10 +3,10 @@
 	<extension name="Joomla" element="joomla" type="file" version="3.5.1" targetplatformversion="2.5" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="3.2.7" targetplatformversion="3.0" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="3.2.7" targetplatformversion="3.1" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="3.6.3" targetplatformversion="3.2" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="3.6.4" targetplatformversion="3.2" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="3.2.7" targetplatformversion="3.2" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="3.6.3" targetplatformversion="3.3" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="3.6.3" targetplatformversion="3.4" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="3.6.3" targetplatformversion="3.5" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="3.6.3" targetplatformversion="3.6" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="3.6.4" targetplatformversion="3.3" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="3.6.4" targetplatformversion="3.4" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="3.6.4" targetplatformversion="3.5" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="3.6.4" targetplatformversion="3.6" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
 </extensionset>

--- a/www/helpsites/helpsites.xml
+++ b/www/helpsites/helpsites.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="iso-8859-1"?>
+<?xml version="1.0" encoding="utf-8"?>
 <joshelp>
 	<sites>
 		<site tag="en-GB" url="https://help.joomla.org/proxy?keyref=Help{major}{minor}:{keyref}&amp;lang={langcode}">English (GB) - Joomla help wiki</site>


### PR DESCRIPTION
This just change the update server to point to 3.6.3.

Before the merge (this is a upstream branch so you can edit it before the merge!) please change this line https://github.com/joomla/update.joomla.org/blob/3.6.4/www/core/sts/extension_sts.xml#L136 to the correct URL on joomla.org!