### PR TITLE
Change to using the real file names for the download packages

### DIFF
--- a/www/core/extension.xml
+++ b/www/core/extension.xml
@@ -8,7 +8,7 @@
 		<version>1.7.0</version>
 		<infourl title="Joomla!">https://www.joomla.org/</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://downloads.joomla.org/cms/joomla25/1-7-0/joomla_1-6-x_to_1-7-0_package-zip?format=zip&amp;jcompat=my.zip</downloadurl>
+			<downloadurl type="full" format="zip">https://downloads.joomla.org/cms/joomla25/1-7-0/Joomla_1.6.x_to_1.7.0_Package.zip</downloadurl>
 		</downloads>
 		<tags>
 			<tag>stable</tag>
@@ -26,7 +26,7 @@
 		<version>2.5.28</version>
 		<infourl title="Joomla!">https://www.joomla.org/announcements/release-news/5574-joomla-2-5-28-released.html</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://downloads.joomla.org/cms/joomla25/2-5-28/joomla_2-5-28-stable-update_package-zip?format=zip&amp;jcompat=my.zip</downloadurl>
+			<downloadurl type="full" format="zip">https://downloads.joomla.org/cms/joomla25/2-5-28/Joomla_2.5.28-Stable-Update_Package.zip</downloadurl>
 		</downloads>
 		<tags>
 			<tag>stable</tag>
@@ -44,7 +44,7 @@
 		<version>2.5.28</version>
 		<infourl title="Joomla!">https://www.joomla.org/announcements/release-news/5574-joomla-2-5-28-released.html</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://downloads.joomla.org/cms/joomla25/2-5-28/joomla_2-5-x_to_2-5-28-stable-patch_package-zip?format=zip&amp;jcompat=my.zip</downloadurl>
+			<downloadurl type="full" format="zip">https://downloads.joomla.org/cms/joomla25/2-5-28/Joomla_2.5.x_to_2.5.28-Stable-Patch_Package.zip</downloadurl>
 		</downloads>
 		<tags>
 			<tag>stable</tag>

--- a/www/core/sts/extension_sts.xml
+++ b/www/core/sts/extension_sts.xml
@@ -8,7 +8,7 @@
 		<version>3.1.3</version>
 		<infourl title="Joomla!">https://www.joomla.org/</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://downloads.joomla.org/cms/joomla3/3-1-3/joomla_3-1-2_to_3-1-3-stable-patch_package-tar-gz?format=gz&amp;jcompat=my.zip</downloadurl>
+			<downloadurl type="full" format="zip">https://downloads.joomla.org/cms/joomla3/3-1-3/Joomla_3.1.2_to_3.1.3-Stable-Patch_Package.tar.gz</downloadurl>
 		</downloads>
 		<tags>
 			<tag>stable</tag>
@@ -26,7 +26,7 @@
 		<version>3.2.7</version>
 		<infourl title="Joomla!">https://www.joomla.org/</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://downloads.joomla.org/cms/joomla3/3-2-7/joomla_3-2-7-stable-update_package-zip?format=zip&amp;jcompat=my.zip</downloadurl>
+			<downloadurl type="full" format="zip">https://downloads.joomla.org/cms/joomla3/3-2-7/Joomla_3.2.7-Stable-Update_Package.zip</downloadurl>
 		</downloads>
 		<tags>
 			<tag>stable</tag>
@@ -44,7 +44,7 @@
 		<version>3.2.7</version>
 		<infourl title="Joomla!">https://www.joomla.org/</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://downloads.joomla.org/cms/joomla3/3-2-7/joomla_3-2-7-stable-update_package-zip?format=zip&amp;jcompat=my.zip</downloadurl>
+			<downloadurl type="full" format="zip">https://downloads.joomla.org/cms/joomla3/3-2-7/Joomla_3.2.7-Stable-Update_Package.zip</downloadurl>
 		</downloads>
 		<tags>
 			<tag>stable</tag>
@@ -62,7 +62,7 @@
 		<version>3.2.7</version>
 		<infourl title="Joomla!">https://www.joomla.org/</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://downloads.joomla.org/cms/joomla3/3-2-7/joomla_3-2-7-stable-update_package-zip?format=zip&amp;jcompat=my.zip</downloadurl>
+			<downloadurl type="full" format="zip">https://downloads.joomla.org/cms/joomla3/3-2-7/Joomla_3.2.7-Stable-Update_Package.zip</downloadurl>
 		</downloads>
 		<tags>
 			<tag>stable</tag>
@@ -80,7 +80,7 @@
 		<version>3.2.7</version>
 		<infourl title="Joomla!">https://www.joomla.org/</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://downloads.joomla.org/cms/joomla3/3-2-7/joomla_3-2-x_to_3-2-7-stable-patch_package-zip?format=zip&amp;jcompat=my.zip</downloadurl>
+			<downloadurl type="full" format="zip">https://downloads.joomla.org/cms/joomla3/3-2-7/Joomla_3.2.x_to_3.2.7-Stable-Patch_Package.zip</downloadurl>
 		</downloads>
 		<tags>
 			<tag>stable</tag>
@@ -98,7 +98,7 @@
 		<version>3.2.7</version>
 		<infourl title="Joomla!">https://www.joomla.org/</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://downloads.joomla.org/cms/joomla3/3-2-7/joomla_3-2-6_to_3-2-7-stable-patch_package-zip?format=zip&amp;jcompat=my.zip</downloadurl>
+			<downloadurl type="full" format="zip">https://downloads.joomla.org/cms/joomla3/3-2-7/Joomla_3.2.6_to_3.2.7-Stable-Patch_Package.zip</downloadurl>
 		</downloads>
 		<tags>
 			<tag>stable</tag>
@@ -116,7 +116,7 @@
 		<version>3.5.1</version>
 		<infourl title="Joomla!">https://www.joomla.org/announcements/release-news/5655-joomla-3-5-1-released.html</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://downloads.joomla.org/cms/joomla3/3-5-1/joomla_3-5-1-stable-update_package-zip?format=zip&amp;jcompat=my.zip</downloadurl>
+			<downloadurl type="full" format="zip">https://downloads.joomla.org/cms/joomla3/3-5-1/Joomla_3.5.1-Stable-Update_Package.zip</downloadurl>
 		</downloads>
 		<tags>
 			<tag>stable</tag>
@@ -135,7 +135,7 @@
 		<version>3.6.4</version>
 		<infourl title="Joomla!">https://www.joomla.org/announcements/release-news/5678-joomla-3-6-4-released.html</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://downloads.joomla.org/cms/joomla3/3-6-4/joomla_3-6-4-stable-update_package-zip?format=zip&amp;jcompat=my.zip</downloadurl>
+			<downloadurl type="full" format="zip">https://downloads.joomla.org/cms/joomla3/3-6-4/Joomla_3.6.4-Stable-Update_Package.zip</downloadurl>
 		</downloads>
 		<tags>
 			<tag>stable</tag>


### PR DESCRIPTION
To fix the issue of Windows systems being unable to write the filename it's generating (the last URL segment) or to use the ability of uploading the package to the site's `tmp` directory and bypassing the need to download the package, the component router on the downloads site has been altered to allow routing by the real file name as well as the URL "friendly" alias.

This PR changes the download URLs to use the real file names instead of the aliases to fix the platform incompatibility issues and get everything working well for older Joomla versions and Windows platforms in general once again.