### PR TITLE
Prepare 3.7.0 Beta 2 release together with the nightly build changes

### DIFF
--- a/www/core/nightlies/next_minor_extension.xml
+++ b/www/core/nightlies/next_minor_extension.xml
@@ -5,10 +5,10 @@
 		<description>Joomla! CMS</description>
 		<element>joomla</element>
 		<type>file</type>
-		<version>3.7.0-beta1</version>
+		<version>3.7.0-beta3</version>
 		<infourl title="Joomla! Nightly Builds">https://developer.joomla.org/nightly-builds.html</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_3.7.0-beta1-dev-Update_Package.zip</downloadurl>
+			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_3.7.0-beta3-dev-Update_Package.zip</downloadurl>
 		</downloads>
 		<tags>
 			<tag>stable</tag>

--- a/www/core/nightlies/next_minor_list.xml
+++ b/www/core/nightlies/next_minor_list.xml
@@ -1,6 +1,6 @@
 <extensionset name="Joomla! Core Nightly Builds" description="Joomla! Core Next Minor Nightly Builds">
-	<extension name="Joomla" element="joomla" type="file" version="3.7.0-beta1" targetplatformversion="3.4" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="3.7.0-beta1" targetplatformversion="3.5" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="3.7.0-beta1" targetplatformversion="3.6" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="3.7.0-beta1" targetplatformversion="3.7" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="3.7.0-beta3" targetplatformversion="3.4" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="3.7.0-beta3" targetplatformversion="3.5" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="3.7.0-beta3" targetplatformversion="3.6" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="3.7.0-beta3" targetplatformversion="3.7" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
 </extensionset>

--- a/www/core/test/extension_test.xml
+++ b/www/core/test/extension_test.xml
@@ -5,10 +5,10 @@
 		<description>Joomla! 3.7 CMS</description>
 		<element>joomla</element>
 		<type>file</type>
-		<version>3.7.0-beta1</version>
+		<version>3.7.0-beta2</version>
 		<infourl title="Joomla!">https://www.joomla.org</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://github.com/joomla/joomla-cms/releases/download/3.7.0-beta1/Joomla_3.7.0-beta1-Beta-Update_Package.zip</downloadurl>
+			<downloadurl type="full" format="zip">https://github.com/joomla/joomla-cms/releases/download/3.7.0-beta2/Joomla_3.7.0-beta2-Beta-Update_Package.zip</downloadurl>
 		</downloads>
 		<tags>
 			<tag>stable</tag>

--- a/www/core/test/list_test.xml
+++ b/www/core/test/list_test.xml
@@ -1,7 +1,7 @@
 <extensionset name="Joomla Core Test Updateserver" description="The Joomla Core Updateserver for Tests of Alpha, Beta und RC Releases">
-	<extension name="Joomla" element="joomla" type="file" version="3.7.0-beta1" targetplatformversion="3.3" detailsurl="https://update.joomla.org/core/test/extension_test.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="3.7.0-beta1" targetplatformversion="3.4" detailsurl="https://update.joomla.org/core/test/extension_test.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="3.7.0-beta1" targetplatformversion="3.5" detailsurl="https://update.joomla.org/core/test/extension_test.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="3.7.0-beta1" targetplatformversion="3.6" detailsurl="https://update.joomla.org/core/test/extension_test.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="3.7.0-beta1" targetplatformversion="3.7" detailsurl="https://update.joomla.org/core/test/extension_test.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="3.7.0-beta2" targetplatformversion="3.3" detailsurl="https://update.joomla.org/core/test/extension_test.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="3.7.0-beta2" targetplatformversion="3.4" detailsurl="https://update.joomla.org/core/test/extension_test.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="3.7.0-beta2" targetplatformversion="3.5" detailsurl="https://update.joomla.org/core/test/extension_test.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="3.7.0-beta2" targetplatformversion="3.6" detailsurl="https://update.joomla.org/core/test/extension_test.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="3.7.0-beta2" targetplatformversion="3.7" detailsurl="https://update.joomla.org/core/test/extension_test.xml" />
 </extensionset>


### PR DESCRIPTION
Prepare 3.7.0 Beta 2 release together with the nightly build changes

#### Note

This PR assumes we get another beta -> beta3 as next release after the beta2 if that changes we just need to fix the nightly build files.