### PR TITLE
Apply changes for the Nightly Builds after 3.7.0 is out

### DIFF
--- a/www/core/nightlies/afternext_minor_extension.xml
+++ b/www/core/nightlies/afternext_minor_extension.xml
@@ -1,20 +1,19 @@
-<?xml version="1.0" ?>
 <updates>
 	<update>
-		<name>Joomla! 3.8.0 Nightly Build</name>
+		<name>Joomla! 3.9.0 Nightly Build</name>
 		<description>Joomla! CMS</description>
 		<element>joomla</element>
 		<type>file</type>
-		<version>3.8.0-dev</version>
+		<version>3.9.0-dev</version>
 		<infourl title="Joomla! Nightly Builds">https://developer.joomla.org/nightly-builds.html</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_3.8.0-dev-Development-Update_Package.zip</downloadurl>
+			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_3.9.0-dev-Development-Update_Package.zip</downloadurl>
 		</downloads>
 		<tags>
 			<tag>stable</tag>
 		</tags>
 		<maintainer>Joomla! PLT</maintainer>
 		<maintainerurl>https://www.joomla.org</maintainerurl>
-		<targetplatform name="joomla" version="3.[45678]" />
+		<targetplatform name="joomla" version="3.[89]" />
 	</update>
 </updates>

--- a/www/core/nightlies/afternext_minor_list.xml
+++ b/www/core/nightlies/afternext_minor_list.xml
@@ -1,0 +1,4 @@
+<extensionset name="Joomla! Core Nightly Builds" description="Joomla! Core After Next Major Nightly Builds">>
+	<extension name="Joomla" element="joomla" type="file" version="3.9.0-dev" targetplatformversion="3.8" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="3.9.0-dev" targetplatformversion="3.9" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
+</extensionset>

--- a/www/core/nightlies/next_major_extension.xml
+++ b/www/core/nightlies/next_major_extension.xml
@@ -15,7 +15,7 @@
 		</tags>
 		<maintainer>Joomla! PLT</maintainer>
 		<maintainerurl>https://www.joomla.org</maintainerurl>
-		<targetplatform name="joomla" version="3.[4567]" />
+		<targetplatform name="joomla" version="3.[456789]" />
 	</update>
 	<update>
 		<name>Joomla! 4.0.0 Nightly Build</name>

--- a/www/core/nightlies/next_major_extension.xml
+++ b/www/core/nightlies/next_major_extension.xml
@@ -5,7 +5,7 @@
 		<description>Joomla! CMS</description>
 		<element>joomla</element>
 		<type>file</type>
-		<version>4.0.0-dev2</version>
+		<version>4.0.0-dev</version>
 		<infourl title="Joomla! Nightly Builds">https://developer.joomla.org/nightly-builds.html</infourl>
 		<downloads>
 			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_4.0.0-dev-Development-Update_Package.zip</downloadurl>
@@ -22,7 +22,7 @@
 		<description>Joomla! CMS</description>
 		<element>joomla</element>
 		<type>file</type>
-		<version>4.0.0-dev2</version>
+		<version>4.0.0-dev</version>
 		<infourl title="Joomla! Nightly Builds">https://developer.joomla.org/nightly-builds.html</infourl>
 		<downloads>
 			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_4.0.0-dev-Development-Update_Package.zip</downloadurl>

--- a/www/core/nightlies/next_major_list.xml
+++ b/www/core/nightlies/next_major_list.xml
@@ -3,5 +3,7 @@
 	<extension name="Joomla" element="joomla" type="file" version="4.0.0-dev2" targetplatformversion="3.5" detailsurl="https://update.joomla.org/core/nightlies/next_major_extension.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="4.0.0-dev2" targetplatformversion="3.6" detailsurl="https://update.joomla.org/core/nightlies/next_major_extension.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="4.0.0-dev2" targetplatformversion="3.7" detailsurl="https://update.joomla.org/core/nightlies/next_major_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="4.0.0-dev2" targetplatformversion="3.8" detailsurl="https://update.joomla.org/core/nightlies/next_major_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="4.0.0-dev2" targetplatformversion="3.9" detailsurl="https://update.joomla.org/core/nightlies/next_major_extension.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="4.0.0-dev2" targetplatformversion="4.0" detailsurl="https://update.joomla.org/core/nightlies/next_major_extension.xml" />
 </extensionset>

--- a/www/core/nightlies/next_major_list.xml
+++ b/www/core/nightlies/next_major_list.xml
@@ -1,9 +1,9 @@
 <extensionset name="Joomla! Core Nightly Builds" description="Joomla! Core Next Major Nightly Builds">
-	<extension name="Joomla" element="joomla" type="file" version="4.0.0-dev2" targetplatformversion="3.4" detailsurl="https://update.joomla.org/core/nightlies/next_major_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="4.0.0-dev2" targetplatformversion="3.5" detailsurl="https://update.joomla.org/core/nightlies/next_major_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="4.0.0-dev2" targetplatformversion="3.6" detailsurl="https://update.joomla.org/core/nightlies/next_major_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="4.0.0-dev2" targetplatformversion="3.7" detailsurl="https://update.joomla.org/core/nightlies/next_major_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="4.0.0-dev2" targetplatformversion="3.8" detailsurl="https://update.joomla.org/core/nightlies/next_major_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="4.0.0-dev2" targetplatformversion="3.9" detailsurl="https://update.joomla.org/core/nightlies/next_major_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="4.0.0-dev2" targetplatformversion="4.0" detailsurl="https://update.joomla.org/core/nightlies/next_major_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="4.0.0-dev" targetplatformversion="3.4" detailsurl="https://update.joomla.org/core/nightlies/next_major_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="4.0.0-dev" targetplatformversion="3.5" detailsurl="https://update.joomla.org/core/nightlies/next_major_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="4.0.0-dev" targetplatformversion="3.6" detailsurl="https://update.joomla.org/core/nightlies/next_major_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="4.0.0-dev" targetplatformversion="3.7" detailsurl="https://update.joomla.org/core/nightlies/next_major_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="4.0.0-dev" targetplatformversion="3.8" detailsurl="https://update.joomla.org/core/nightlies/next_major_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="4.0.0-dev" targetplatformversion="3.9" detailsurl="https://update.joomla.org/core/nightlies/next_major_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="4.0.0-dev" targetplatformversion="4.0" detailsurl="https://update.joomla.org/core/nightlies/next_major_extension.xml" />
 </extensionset>

--- a/www/core/nightlies/next_minor_extension.xml
+++ b/www/core/nightlies/next_minor_extension.xml
@@ -22,7 +22,7 @@
 		<description>Joomla! CMS</description>
 		<element>joomla</element>
 		<type>file</type>
-		<version>3.9.0-dev1</version>
+		<version>3.9.0-dev</version>
 		<infourl title="Joomla! Nightly Builds">https://developer.joomla.org/nightly-builds.html</infourl>
 		<downloads>
 			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_3.9.0-dev-Development-Update_Package.zip</downloadurl>

--- a/www/core/nightlies/next_minor_extension.xml
+++ b/www/core/nightlies/next_minor_extension.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" ?>
 <updates>
 	<update>
-		<name>Joomla! 3.7.0 Nightly Build</name>
+		<name>Joomla! 3.8.0 Nightly Build</name>
 		<description>Joomla! CMS</description>
 		<element>joomla</element>
 		<type>file</type>
-		<version>3.7.0-rc2</version>
+		<version>3.8.0-dev</version>
 		<infourl title="Joomla! Nightly Builds">https://developer.joomla.org/nightly-builds.html</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_3.7.0-rc2-dev-Update_Package.zip</downloadurl>
+			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_3.8.0-dev-Development-Update_Package.zip</downloadurl>
 		</downloads>
 		<tags>
 			<tag>stable</tag>
@@ -16,5 +16,22 @@
 		<maintainer>Joomla! PLT</maintainer>
 		<maintainerurl>https://www.joomla.org</maintainerurl>
 		<targetplatform name="joomla" version="3.[4567]" />
+	</update>
+	<update>
+		<name>Joomla! 3.9.0 Nightly Build</name>
+		<description>Joomla! CMS</description>
+		<element>joomla</element>
+		<type>file</type>
+		<version>3.9.0-dev1</version>
+		<infourl title="Joomla! Nightly Builds">https://developer.joomla.org/nightly-builds.html</infourl>
+		<downloads>
+			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_3.9.0-dev-Development-Update_Package.zip</downloadurl>
+		</downloads>
+		<tags>
+			<tag>stable</tag>
+		</tags>
+		<maintainer>Joomla! PLT</maintainer>
+		<maintainerurl>https://www.joomla.org</maintainerurl>
+		<targetplatform name="joomla" version="3.[89]" />
 	</update>
 </updates>

--- a/www/core/nightlies/next_minor_list.xml
+++ b/www/core/nightlies/next_minor_list.xml
@@ -1,6 +1,8 @@
 <extensionset name="Joomla! Core Nightly Builds" description="Joomla! Core Next Minor Nightly Builds">
-	<extension name="Joomla" element="joomla" type="file" version="3.7.0-rc2" targetplatformversion="3.4" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="3.7.0-rc2" targetplatformversion="3.5" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="3.7.0-rc2" targetplatformversion="3.6" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="3.7.0-rc2" targetplatformversion="3.7" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="3.8.0-dev" targetplatformversion="3.4" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="3.8.0-dev" targetplatformversion="3.5" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="3.8.0-dev" targetplatformversion="3.6" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="3.8.0-dev" targetplatformversion="3.7" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="3.9.0-dev" targetplatformversion="3.8" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="3.9.0-dev" targetplatformversion="3.9" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
 </extensionset>

--- a/www/core/nightlies/next_minor_list.xml
+++ b/www/core/nightlies/next_minor_list.xml
@@ -3,6 +3,5 @@
 	<extension name="Joomla" element="joomla" type="file" version="3.8.0-dev" targetplatformversion="3.5" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="3.8.0-dev" targetplatformversion="3.6" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="3.8.0-dev" targetplatformversion="3.7" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="3.9.0-dev" targetplatformversion="3.8" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="3.9.0-dev" targetplatformversion="3.9" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="3.8.0-dev" targetplatformversion="3.8" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
 </extensionset>

--- a/www/core/nightlies/next_patch_extension.xml
+++ b/www/core/nightlies/next_patch_extension.xml
@@ -1,21 +1,21 @@
 <?xml version="1.0" ?>
 <updates>
 	<update>
-		<name>Joomla! 3.6.4 Nightly Build</name>
+		<name>Joomla! 3.7.1 Nightly Build</name>
 		<description>Joomla! CMS</description>
 		<element>joomla</element>
 		<type>file</type>
-		<version>3.6.6-dev1</version>
+		<version>3.7.1-dev</version>
 		<infourl title="Joomla! Nightly Builds">https://developer.joomla.org/nightly-builds.html</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_3.6.4-dev-Development-Update_Package.zip</downloadurl>
+			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_3.7.1-dev-Development-Update_Package.zip</downloadurl>
 		</downloads>
 		<tags>
 			<tag>stable</tag>
 		</tags>
 		<maintainer>Joomla! PLT</maintainer>
 		<maintainerurl>https://www.joomla.org</maintainerurl>
-		<targetplatform name="joomla" version="3.[456]" />
+		<targetplatform name="joomla" version="3.[4567]" />
 	</update>
 </updates>
 

--- a/www/core/nightlies/next_patch_list.xml
+++ b/www/core/nightlies/next_patch_list.xml
@@ -1,5 +1,6 @@
 <extensionset name="Joomla! Core Nightly Builds" description="Joomla! Core Next Patch Nightly Builds">
-	<extension name="Joomla" element="joomla" type="file" version="3.6.6-dev1" targetplatformversion="3.4" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="3.6.6-dev1" targetplatformversion="3.5" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="3.6.6-dev1" targetplatformversion="3.6" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="3.7.1-dev" targetplatformversion="3.4" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="3.7.1-dev" targetplatformversion="3.5" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="3.7.1-dev" targetplatformversion="3.6" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="3.7.1-dev" targetplatformversion="3.7" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
 </extensionset>


### PR DESCRIPTION
Apply changes for the Nightly Builds after 3.7.0 is out.

#### Update paths

##### Next Major Update Server

If you a on `3.[456789]` => Install & reinstall 4.0.0-dev

##### Next Minor Update Server

If you a on `3.[45678]` => Install & reinstall 3.8.0-dev

##### After Next Minor Update Server

If you are on `3.[89]` => Install & reinstall 3.9-dev

##### Next Patch Update Server

If you are on `3.[4567]` => Install & reinstall 3.7.1-dev

##### Important

We first need to make sure the files are beeing build over night and we need to waint until 3.7.0 is out of the door and we can move this to the next round of dev mode.

cc @mbabker @rdeutz 