### PR TITLE
[4.0] Add support databases and php minimum to 4.0

### DIFF
--- a/www/core/nightlies/next_major_extension.xml
+++ b/www/core/nightlies/next_major_extension.xml
@@ -13,9 +13,11 @@
 		<tags>
 			<tag>stable</tag>
 		</tags>
+		<supported_databases mysql="5.5.3" postgresql="9.2" />
+		<php_minimum>7.0.0</php_minimum>
 		<maintainer>Joomla! PLT</maintainer>
 		<maintainerurl>https://www.joomla.org</maintainerurl>
-		<targetplatform name="joomla" version="3.[456789]" />
+		<targetplatform name="joomla" version="3.[789]" />
 	</update>
 	<update>
 		<name>Joomla! 4.0.0 Nightly Build</name>
@@ -30,6 +32,8 @@
 		<tags>
 			<tag>stable</tag>
 		</tags>
+		<supported_databases mysql="5.5.3" postgresql="9.2" />
+		<php_minimum>7.0.0</php_minimum>
 		<maintainer>Joomla! PLT</maintainer>
 		<maintainerurl>https://www.joomla.org</maintainerurl>
 		<targetplatform name="joomla" version="4.[01]" />

--- a/www/core/nightlies/next_major_list.xml
+++ b/www/core/nightlies/next_major_list.xml
@@ -1,7 +1,4 @@
 <extensionset name="Joomla! Core Nightly Builds" description="Joomla! Core Next Major Nightly Builds">
-	<extension name="Joomla" element="joomla" type="file" version="4.0.0-dev" targetplatformversion="3.4" detailsurl="https://update.joomla.org/core/nightlies/next_major_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="4.0.0-dev" targetplatformversion="3.5" detailsurl="https://update.joomla.org/core/nightlies/next_major_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="4.0.0-dev" targetplatformversion="3.6" detailsurl="https://update.joomla.org/core/nightlies/next_major_extension.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="4.0.0-dev" targetplatformversion="3.7" detailsurl="https://update.joomla.org/core/nightlies/next_major_extension.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="4.0.0-dev" targetplatformversion="3.8" detailsurl="https://update.joomla.org/core/nightlies/next_major_extension.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="4.0.0-dev" targetplatformversion="3.9" detailsurl="https://update.joomla.org/core/nightlies/next_major_extension.xml" />


### PR DESCRIPTION
Implement the checks done here by adding the php_minumum and supported_databases tag to the 4.0 update server

https://github.com/joomla/joomla-cms/blob/staging/administrator/components/com_admin/postinstall/joomla40checks.php