### PR TITLE
Allow browser injected css / js for styling of XML files

### DIFF
--- a/www/.htaccess
+++ b/www/.htaccess
@@ -18,7 +18,7 @@
 	# Strict-Transport-Security
 	Header always set Strict-Transport-Security "max-age=31536000; includeSubDomains"
 	# Content Security Policy
-	Header always set Content-Security-Policy "default-src 'self'; report-uri https://community.joomla.org/scripts/csp-reporter.php?source=update.joomla.org"
+	Header always set Content-Security-Policy "default-src 'self'; style-src sha256-nx7T2vM3FG2GqDCK5NErQR6tT6iOS/rBjaBaUvmACC0= sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=; report-uri https://community.joomla.org/scripts/csp-reporter.php?source=update.joomla.org"
 </IfModule>
 
 <FilesMatch "\.(txt|zip|html|gif|jpeg|png|flv|swf|ico)$">

--- a/www/.htaccess
+++ b/www/.htaccess
@@ -18,7 +18,7 @@
 	# Strict-Transport-Security
 	Header always set Strict-Transport-Security "max-age=31536000; includeSubDomains"
 	# Content Security Policy
-	Header always set Content-Security-Policy "default-src 'self'; style-src sha256-nx7T2vM3FG2GqDCK5NErQR6tT6iOS/rBjaBaUvmACC0= sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=; script-src res://edgehtml.dll; report-uri https://community.joomla.org/scripts/csp-reporter.php?source=update.joomla.org"
+	Header always set Content-Security-Policy "default-src 'self'; style-src 'sha256-+DU9sPRqEitE7XVlE+lj+PHklv5FZNUL7m9mEUQWWD8=' 'sha256-nx7T2vM3FG2GqDCK5NErQR6tT6iOS/rBjaBaUvmACC0=' 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='; script-src res://edgehtml.dll; report-uri https://community.joomla.org/scripts/csp-reporter.php?source=update.joomla.org"
 </IfModule>
 
 <FilesMatch "\.(txt|zip|html|gif|jpeg|png|flv|swf|ico)$">

--- a/www/.htaccess
+++ b/www/.htaccess
@@ -18,7 +18,7 @@
 	# Strict-Transport-Security
 	Header always set Strict-Transport-Security "max-age=31536000; includeSubDomains"
 	# Content Security Policy
-	Header always set Content-Security-Policy "default-src 'self'; style-src sha256-nx7T2vM3FG2GqDCK5NErQR6tT6iOS/rBjaBaUvmACC0= sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=; report-uri https://community.joomla.org/scripts/csp-reporter.php?source=update.joomla.org"
+	Header always set Content-Security-Policy "default-src 'self'; style-src sha256-nx7T2vM3FG2GqDCK5NErQR6tT6iOS/rBjaBaUvmACC0= sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=; script-src res://edgehtml.dll; report-uri https://community.joomla.org/scripts/csp-reporter.php?source=update.joomla.org"
 </IfModule>
 
 <FilesMatch "\.(txt|zip|html|gif|jpeg|png|flv|swf|ico)$">

--- a/www/.htaccess
+++ b/www/.htaccess
@@ -18,7 +18,7 @@
 	# Strict-Transport-Security
 	Header always set Strict-Transport-Security "max-age=31536000; includeSubDomains"
 	# Content Security Policy
-	Header always set Content-Security-Policy "default-src 'self'; style-src 'sha256-+DU9sPRqEitE7XVlE+lj+PHklv5FZNUL7m9mEUQWWD8=' 'sha256-nx7T2vM3FG2GqDCK5NErQR6tT6iOS/rBjaBaUvmACC0=' 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='; script-src res://edgehtml.dll; report-uri https://community.joomla.org/scripts/csp-reporter.php?source=update.joomla.org"
+	Header always set Content-Security-Policy "default-src 'self'; style-src 'sha256-+DU9sPRqEitE7XVlE+lj+PHklv5FZNUL7m9mEUQWWD8=' 'sha256-nx7T2vM3FG2GqDCK5NErQR6tT6iOS/rBjaBaUvmACC0=' 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=' 'sha256-+4NT+OrdhKuuzPsYfY1xAagRSTagGDc0vRVIzQrnWbE='; script-src res://edgehtml.dll; report-uri https://community.joomla.org/scripts/csp-reporter.php?source=update.joomla.org"
 </IfModule>
 
 <FilesMatch "\.(txt|zip|html|gif|jpeg|png|flv|swf|ico)$">


### PR DESCRIPTION
With this two hashes we white list the browser generated css / js to style XML files.

Tested browsers:
- Chrome
- FF (seams to ignore that thing completely at that point)
- Edge

Open Browsers:
- Safari on Mac

## How to test

- Access this page: https://update.joomla.org/core/list.xml via a browser
- Currently the inline styles that make the XML pretty are blocked
- Check the browser console
- Apply this one & in the browsers above this should work.

Please report the generated hash in Safari on Mac so we can white list this here too.