### PR TITLE
[3.9] Joomla 3.9-beta1

### DIFF
--- a/www/core/test/extension_test.xml
+++ b/www/core/test/extension_test.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" ?>
 <updates>
 	<update>
-		<name>Joomla! 3.8</name>
-		<description>Joomla! 3.8 CMS</description>
+		<name>Joomla! 3.9</name>
+		<description>Joomla! 3.9 CMS</description>
 		<element>joomla</element>
 		<type>file</type>
-		<version>3.8.12-rc</version>
+		<version>3.9.0-beta1</version>
 		<infourl title="Joomla!">https://www.joomla.org</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://github.com/joomla/joomla-cms/releases/download/3.8.12-rc/Joomla_3.8.12-rc-Release_Candidate-Update_Package.zip</downloadurl>
+			<downloadurl type="full" format="zip">https://github.com/joomla/joomla-cms/releases/download/3.9.0-beta1/Joomla_3.9.0-beta1-Beta-Update_Package.zip</downloadurl>
 		</downloads>
 		<tags>
 			<tag>stable</tag>
@@ -19,21 +19,21 @@
 		<php_minimum>5.3.10</php_minimum>
 	</update>
 	<update>
-		<name>Joomla! 3.8</name>
-		<description>Joomla! 3.8 CMS</description>
+		<name>Joomla! 3.9</name>
+		<description>Joomla! 3.9 CMS</description>
 		<element>joomla</element>
 		<type>file</type>
-		<version>3.8.12-rc</version>
+		<version>3.9.0-beta1</version>
 		<infourl title="Joomla!">https://www.joomla.org</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://github.com/joomla/joomla-cms/releases/download/3.8.12-rc/Joomla_3.8.12-rc-Release_Candidate-Update_Package.zip</downloadurl>
+			<downloadurl type="full" format="zip">https://github.com/joomla/joomla-cms/releases/download/3.9.0-beta1/Joomla_3.9.0-beta1-Beta-Update_Package.zip</downloadurl>
 		</downloads>
 		<tags>
 			<tag>stable</tag>
 		</tags>
 		<maintainer>Joomla! PLT</maintainer>
 		<maintainerurl>https://www.joomla.org</maintainerurl>
-		<targetplatform name="joomla" version="3.[78]"/>
+		<targetplatform name="joomla" version="3.[789]"/>
 		<php_minimum>5.3.10</php_minimum>
 	</update>
 </updates>

--- a/www/core/test/list_test.xml
+++ b/www/core/test/list_test.xml
@@ -2,9 +2,9 @@
 	<extension name="Joomla" element="joomla" type="file" version="3.6.5" targetplatformversion="3.3" detailsurl="https://update.joomla.org/core/test/extension_test.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="3.6.5" targetplatformversion="3.4" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="3.6.5" targetplatformversion="3.5" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="3.9.0" targetplatformversion="3.6.5" detailsurl="https://update.joomla.org/core/test/extension_test.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="3.9.0-beta1" targetplatformversion="3.6.5" detailsurl="https://update.joomla.org/core/test/extension_test.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="3.6.5" targetplatformversion="3.6" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="3.9.0" targetplatformversion="3.7" detailsurl="https://update.joomla.org/core/test/extension_test.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="3.9.0" targetplatformversion="3.8" detailsurl="https://update.joomla.org/core/test/extension_test.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="3.9.0" targetplatformversion="3.9" detailsurl="https://update.joomla.org/core/test/extension_test.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="3.9.0-beta1" targetplatformversion="3.7" detailsurl="https://update.joomla.org/core/test/extension_test.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="3.9.0-beta1" targetplatformversion="3.8" detailsurl="https://update.joomla.org/core/test/extension_test.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="3.9.0-beta1" targetplatformversion="3.9" detailsurl="https://update.joomla.org/core/test/extension_test.xml" />
 </extensionset>

--- a/www/core/test/list_test.xml
+++ b/www/core/test/list_test.xml
@@ -2,8 +2,9 @@
 	<extension name="Joomla" element="joomla" type="file" version="3.6.5" targetplatformversion="3.3" detailsurl="https://update.joomla.org/core/test/extension_test.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="3.6.5" targetplatformversion="3.4" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="3.6.5" targetplatformversion="3.5" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="3.8.12-rc" targetplatformversion="3.6.5" detailsurl="https://update.joomla.org/core/test/extension_test.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="3.9.0" targetplatformversion="3.6.5" detailsurl="https://update.joomla.org/core/test/extension_test.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="3.6.5" targetplatformversion="3.6" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="3.8.12-rc" targetplatformversion="3.7" detailsurl="https://update.joomla.org/core/test/extension_test.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="3.8.12-rc" targetplatformversion="3.8" detailsurl="https://update.joomla.org/core/test/extension_test.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="3.9.0" targetplatformversion="3.7" detailsurl="https://update.joomla.org/core/test/extension_test.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="3.9.0" targetplatformversion="3.8" detailsurl="https://update.joomla.org/core/test/extension_test.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="3.9.0" targetplatformversion="3.9" detailsurl="https://update.joomla.org/core/test/extension_test.xml" />
 </extensionset>


### PR DESCRIPTION
This are the changes for the 3.9.0-beta1 release pointing our tests server to 3.9.0-beta1 (when released)