### PR TITLE
Make infourl titles useful

### DIFF
--- a/www/core/sts/extension_sts.xml
+++ b/www/core/sts/extension_sts.xml
@@ -114,7 +114,7 @@
 		<element>joomla</element>
 		<type>file</type>
 		<version>3.5.1</version>
-		<infourl title="Joomla!">https://www.joomla.org/announcements/release-news/5655-joomla-3-5-1-released.html</infourl>
+		<infourl title="Joomla! 3.5.1 Released">https://www.joomla.org/announcements/release-news/5655-joomla-3-5-1-released.html</infourl>
 		<downloads>
 			<downloadurl type="full" format="zip">https://downloads.joomla.org/cms/joomla3/3-5-1/Joomla_3.5.1-Stable-Update_Package.zip</downloadurl>
 		</downloads>
@@ -133,7 +133,7 @@
 		<element>joomla</element>
 		<type>file</type>
 		<version>3.6.5</version>
-		<infourl title="Joomla!">https://www.joomla.org/announcements/release-news/5693-joomla-3-6-5-released.html</infourl>
+		<infourl title="Joomla! 3.6.5 Released">https://www.joomla.org/announcements/release-news/5693-joomla-3-6-5-released.html</infourl>
 		<downloads>
 			<downloadurl type="full" format="zip">https://downloads.joomla.org/cms/joomla3/3-6-5/Joomla_3.6.5-Stable-Update_Package.zip</downloadurl>
 		</downloads>
@@ -152,7 +152,7 @@
 		<element>joomla</element>
 		<type>file</type>
 		<version>3.9.10</version>
-		<infourl title="Joomla!">https://www.joomla.org/announcements/release-news/5774-joomla-3-9-10-release.html</infourl>
+		<infourl title="Joomla 3.9.10 Release">https://www.joomla.org/announcements/release-news/5774-joomla-3-9-10-release.html</infourl>
 		<downloads>
 			<downloadurl type="full" format="zip">https://downloads.joomla.org/cms/joomla3/3-9-10/Joomla_3.9.10-Stable-Update_Package.zip</downloadurl>
 		</downloads>
@@ -171,7 +171,7 @@
 		<element>joomla</element>
 		<type>file</type>
 		<version>3.9.10</version>
-		<infourl title="Joomla!">https://www.joomla.org/announcements/release-news/5774-joomla-3-9-10-release.html</infourl>
+		<infourl title="Joomla 3.9.10 Release">https://www.joomla.org/announcements/release-news/5774-joomla-3-9-10-release.html</infourl>
 		<downloads>
 			<downloadurl type="full" format="zip">https://downloads.joomla.org/cms/joomla3/3-9-10/Joomla_3.9.10-Stable-Update_Package.zip</downloadurl>
 			<downloadsource type="full" format="zip">https://github.com/joomla/joomla-cms/releases/download/3.9.10/Joomla_3.9.10-Stable-Update_Package.zip</downloadsource>


### PR DESCRIPTION
These titles are displayed on the update component's layout when showing info about the new release.  Instead of showing just the word "Joomla!" for every release, instead the article's title should be used for a slight UX improvement.

Pre-patch:
![Screen Shot 2019-07-15 at 10 25 32 AM](https://user-images.githubusercontent.com/368545/61228065-23396480-a6eb-11e9-8992-5a57c5ca6174.png)

Post-patch:
![Screen Shot 2019-07-15 at 10 25 58 AM](https://user-images.githubusercontent.com/368545/61228081-2896af00-a6eb-11e9-94ae-845e06695664.png)
