### PR TITLE
Fix testing update servers minimum stability

### DIFF
--- a/www/core/test/extension_test.xml
+++ b/www/core/test/extension_test.xml
@@ -11,7 +11,7 @@
 			<downloadurl type="full" format="zip">https://github.com/joomla/joomla-cms/releases/download/3.9.11-rc/Joomla_3.9.11-rc-Release_Candidate-Update_Package.zip</downloadurl>
 		</downloads>
 		<tags>
-			<tag>rc</tag>
+			<tag>stable</tag>
 		</tags>
 		<maintainer>Joomla! Production Department</maintainer>
 		<maintainerurl>https://www.joomla.org</maintainerurl>
@@ -29,7 +29,7 @@
 			<downloadurl type="full" format="zip">https://github.com/joomla/joomla-cms/releases/download/3.9.11-rc/Joomla_3.9.11-rc-Release_Candidate-Update_Package.zip</downloadurl>
 		</downloads>
 		<tags>
-			<tag>rc</tag>
+			<tag>stable</tag>
 		</tags>
 		<sha256>0e9128bc1f901b319f37617f78e6717462bc538d154dc6775eb5057e35a3a9f6</sha256>
 		<sha384>298879fc0cb902c16c31ef6b70f7982933b1c1eaf2ba9aeffdfa2fd9b170a24ff3a51045ef0760d0c91438f9dacb8e4e</sha384>


### PR DESCRIPTION
Workaround of this issue here: https://github.com/joomla/joomla-cms/issues/25827

As mention here: https://github.com/joomla/joomla-cms/issues/25766#issuecomment-520575725 the collection update server does not support yet minimum stability so move it back to disable this option.