### PR TITLE
[4.0] Make it possible for 3.10 to find the 4.0.0-dev updates

### DIFF
--- a/www/core/nightlies/next_major_extension.xml
+++ b/www/core/nightlies/next_major_extension.xml
@@ -36,6 +36,25 @@
 		<php_minimum>7.2.0</php_minimum>
 		<maintainer>Joomla! Production Department</maintainer>
 		<maintainerurl>https://www.joomla.org</maintainerurl>
+		<targetplatform name="joomla" version="3.10" />
+	</update>
+	<update>
+		<name>Joomla! 4.0.0 Nightly Build</name>
+		<description>Joomla! CMS</description>
+		<element>joomla</element>
+		<type>file</type>
+		<version>4.0.0-alpha12-dev</version>
+		<infourl title="Joomla! Nightly Builds">https://developer.joomla.org/nightly-builds.html</infourl>
+		<downloads>
+			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_4.0.0-alpha12-dev-Development-Update_Package.zip</downloadurl>
+		</downloads>
+		<tags>
+			<tag>stable</tag>
+		</tags>
+		<supported_databases mysql="5.6" postgresql="11.0" />
+		<php_minimum>7.2.0</php_minimum>
+		<maintainer>Joomla! Production Department</maintainer>
+		<maintainerurl>https://www.joomla.org</maintainerurl>
 		<targetplatform name="joomla" version="4.0" />
 	</update>
 </updates>


### PR DESCRIPTION
Make sure 3.10 can find the update to 4.0-dev cc @HLeithner @wilsonge 

As reported by @brianteeman here: https://github.com/joomla/joomla-cms/issues/26048