### PR TITLE
[4.0] Add mariadb to the supported databases for Joomla 4.0 update server

### DIFF
--- a/www/core/nightlies/next_major_extension.xml
+++ b/www/core/nightlies/next_major_extension.xml
@@ -13,7 +13,7 @@
 		<tags>
 			<tag>stable</tag>
 		</tags>
-		<supported_databases mysql="5.6" postgresql="11.0" />
+		<supported_databases mysql="5.6" mariadb="10.1" postgresql="11.0" />
 		<php_minimum>7.2.0</php_minimum>
 		<maintainer>Joomla! Production Department</maintainer>
 		<maintainerurl>https://www.joomla.org</maintainerurl>
@@ -32,7 +32,7 @@
 		<tags>
 			<tag>stable</tag>
 		</tags>
-		<supported_databases mysql="5.6" postgresql="11.0" />
+		<supported_databases mysql="5.6" mariadb="10.1" postgresql="11.0" />
 		<php_minimum>7.2.0</php_minimum>
 		<maintainer>Joomla! Production Department</maintainer>
 		<maintainerurl>https://www.joomla.org</maintainerurl>


### PR DESCRIPTION
As of https://github.com/joomla/joomla-cms/pull/26079 we support the specific checking for the mariadb this here adds the [suggested minimum version (10.1)](https://github.com/joomla/update.joomla.org/pull/145#issuecomment-531209634) to the update server.

cc @wilsonge @HLeithner 

