### PR TITLE
[4.0] Drop official 3.9 to 4.0 upgrade path

### DIFF
--- a/www/core/nightlies/next_major_extension.xml
+++ b/www/core/nightlies/next_major_extension.xml
@@ -17,7 +17,7 @@
 		<php_minimum>7.2.0</php_minimum>
 		<maintainer>Joomla! Production Department</maintainer>
 		<maintainerurl>https://www.joomla.org</maintainerurl>
-		<targetplatform name="joomla" version="3.(9|10)" />
+		<targetplatform name="joomla" version="3.10" />
 	</update>
 	<update>
 		<name>Joomla! 4.0.0 Nightly Build</name>

--- a/www/core/nightlies/next_major_list.xml
+++ b/www/core/nightlies/next_major_list.xml
@@ -1,5 +1,4 @@
 <extensionset name="Joomla! Core Nightly Builds" description="Joomla! Core Next Major Nightly Builds">
-	<extension name="Joomla" element="joomla" type="file" version="4.0.0-beta1-dev" targetplatformversion="3.9" detailsurl="https://update.joomla.org/core/nightlies/next_major_extension.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="4.0.0-beta1-dev" targetplatformversion="3.10" detailsurl="https://update.joomla.org/core/nightlies/next_major_extension.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="4.0.0-beta1-dev" targetplatformversion="4.0" detailsurl="https://update.joomla.org/core/nightlies/next_major_extension.xml" />
 </extensionset>


### PR DESCRIPTION
[As requested](https://github.com/joomla/joomla-cms/pull/27129#issuecomment-558120468) this removes the official upgrade path from 3.9 to 4.0  and forces 3.10 to be installed to see the update.