### PR TITLE
[4.0] Update PHP minimum to 7.2.5

### DIFF
--- a/www/core/nightlies/next_major_extension.xml
+++ b/www/core/nightlies/next_major_extension.xml
@@ -14,7 +14,7 @@
 			<tag>stable</tag>
 		</tags>
 		<supported_databases mysql="5.6" mariadb="10.1" postgresql="11.0" />
-		<php_minimum>7.2.0</php_minimum>
+		<php_minimum>7.2.5</php_minimum>
 		<maintainer>Joomla! Production Department</maintainer>
 		<maintainerurl>https://www.joomla.org</maintainerurl>
 		<targetplatform name="joomla" version="3.10" />
@@ -33,7 +33,7 @@
 			<tag>stable</tag>
 		</tags>
 		<supported_databases mysql="5.6" mariadb="10.1" postgresql="11.0" />
-		<php_minimum>7.2.0</php_minimum>
+		<php_minimum>7.2.5</php_minimum>
 		<maintainer>Joomla! Production Department</maintainer>
 		<maintainerurl>https://www.joomla.org</maintainerurl>
 		<targetplatform name="joomla" version="4.0" />


### PR DESCRIPTION
As of: https://volunteers.joomla.org/departments/production/reports/1128-production-dept-meeting-november-05-2019 PHP 7.2.5 is mimimum for 4.0.

cc @HLeithner @wilsonge 