### PR TITLE
Allow updates from 3.9 to 3.10-alpha

### DIFF
--- a/www/core/test/extension_test.xml
+++ b/www/core/test/extension_test.xml
@@ -57,7 +57,7 @@
 		<sha512>19b1bd2dc58e247f24ab698bb3eb8e13a3c9126f09c8032fe1144a8a582891a55904a4a32cef677a8ee63add60b305ed3aa4df0816a1b10884faceb444a373b2</sha512>
 		<maintainer>Joomla! Production Department</maintainer>
 		<maintainerurl>https://www.joomla.org</maintainerurl>
-		<targetplatform name="joomla" version="3.10" />
+		<targetplatform name="joomla" version="3.(9|10)" />
 		<php_minimum>5.3.10</php_minimum>
 	</update>
 	<update>

--- a/www/core/test/list_test.xml
+++ b/www/core/test/list_test.xml
@@ -7,6 +7,7 @@
 	<extension name="Joomla" element="joomla" type="file" version="3.9.20-rc" targetplatformversion="3.7" detailsurl="https://update.joomla.org/core/test/extension_test.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="3.9.20-rc" targetplatformversion="3.8" detailsurl="https://update.joomla.org/core/test/extension_test.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="3.9.20-rc" targetplatformversion="3.9" detailsurl="https://update.joomla.org/core/test/extension_test.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="3.10.0-alpha1" targetplatformversion="3.9.20" detailsurl="https://update.joomla.org/core/test/extension_test.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="3.10.0-alpha1" targetplatformversion="3.10" detailsurl="https://update.joomla.org/core/test/extension_test.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="4.0.0-beta3" targetplatformversion="4.0" detailsurl="https://update.joomla.org/core/test/extension_test.xml" />
 </extensionset>


### PR DESCRIPTION
Seems I missed that. With this here now updates from 3.9.20 to 3.10.0-alpha should be possible with the testing update server.