### PR TITLE
Update list_sts.xml for 3.10.2 already now so people testing 3.10.2-rc1 can test updating to 4.0.2 with live update

### DIFF
--- a/www/core/sts/list_sts.xml
+++ b/www/core/sts/list_sts.xml
@@ -15,5 +15,6 @@
 	<extension name="Joomla" element="joomla" type="file" version="3.10.1" targetplatformversion="3.9" detailsurl="https://update.joomla.org/core/extension.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="3.10.1" targetplatformversion="3.10.0" detailsurl="https://update.joomla.org/core/extension.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="4.0.2" targetplatformversion="3.10.1" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="4.0.2" targetplatformversion="3.10.2" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="4.0.2" targetplatformversion="4.0" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
 </extensionset>


### PR DESCRIPTION
Add the new targetplatformversion="3.10.2" now so people testing 3.10.2-rc1 can test updating to 4.0.2 with live update.

Up to now I see no regular expression syntax being used for the targetplatformversion, so I did not start with that but added a new row for 3.10.2.

If we continue with that for the remaining life time of 3.10 it could become a lot of rows, so maybe we should do something like this instead for the targetplatformversion:

`"3.10.(1|2)"`, which in future might become `"3.10.(1|2|3|4|5|6|7|8|9|10|11)"`

or

`"3.10.[12]"` or to be prepared for future `"3.10.[1-2]"`, which in future might become `"3.10.([1-9]|10|11)"`

Both would work here, I've just tested with an own custom update URL.

@zero-24 What do you prefer?