### PR TITLE
Update next_minor_extension.xml to 4.2.0-beta2-dev

### DIFF
--- a/www/core/nightlies/next_minor_extension.xml
+++ b/www/core/nightlies/next_minor_extension.xml
@@ -5,10 +5,10 @@
 		<description>Joomla! CMS</description>
 		<element>joomla</element>
 		<type>file</type>
-		<version>4.2.0-dev</version>
+		<version>4.2.0-beta2-dev</version>
 		<infourl title="Joomla! Nightly Builds">https://developer.joomla.org/nightly-builds.html</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_4.2.0-beta1-dev-Development-Update_Package.zip</downloadurl>
+			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_4.2.0-beta2-dev-Development-Update_Package.zip</downloadurl>
 		</downloads>
 		<tags>
 			<tag>stable</tag>
@@ -24,10 +24,10 @@
 		<description>Joomla! CMS</description>
 		<element>joomla</element>
 		<type>file</type>
-		<version>4.2.0-dev</version>
+		<version>4.2.0-beta2-dev</version>
 		<infourl title="Joomla! Nightly Builds">https://developer.joomla.org/nightly-builds.html</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_4.2.0-beta1-dev-Development-Update_Package.zip</downloadurl>
+			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_4.2.0-beta2-dev-Development-Update_Package.zip</downloadurl>
 		</downloads>
 		<tags>
 			<tag>stable</tag>

--- a/www/core/nightlies/next_minor_list.xml
+++ b/www/core/nightlies/next_minor_list.xml
@@ -1,6 +1,6 @@
 <extensionset name="Joomla! Core Nightly Builds" description="Joomla! Core Next Minor Nightly Builds">
-	<extension name="Joomla" element="joomla" type="file" version="4.2.0-dev" targetplatformversion="3.10" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="4.2.0-dev" targetplatformversion="4.0" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="4.2.0-dev" targetplatformversion="4.1" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="4.2.0-dev" targetplatformversion="4.2" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="4.2.0-beta2-dev" targetplatformversion="3.10" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="4.2.0-beta2-dev" targetplatformversion="4.0" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="4.2.0-beta2-dev" targetplatformversion="4.1" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="4.2.0-beta2-dev" targetplatformversion="4.2" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
 </extensionset>


### PR DESCRIPTION
Update the nightly build download URL for 4.2-dev to the latest version. This has been forgotten somehow when making 4.2.0-beta1. See https://developer.joomla.org/nightly-builds.html for the correct URL.