### PR TITLE
make sure every 4.x goes to 4.1.5 before getting the 4.2.0 update as a workaround

### DIFF
--- a/www/core/list.xml
+++ b/www/core/list.xml
@@ -14,7 +14,8 @@
 	<extension name="Joomla" element="joomla" type="file" version="3.10.11" targetplatformversion="3.8" detailsurl="https://update.joomla.org/core/extension.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="3.10.11" targetplatformversion="3.9" detailsurl="https://update.joomla.org/core/extension.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="3.10.11" targetplatformversion="3.10" detailsurl="https://update.joomla.org/core/extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="4.2.0" targetplatformversion="4.0" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="4.2.0" targetplatformversion="4.1" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="4.1.5" targetplatformversion="4.0" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="4.1.5" targetplatformversion="4.1" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="4.2.0" targetplatformversion="4.1.5" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="4.2.0" targetplatformversion="4.2" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
 </extensionset>

--- a/www/core/sts/extension_sts.xml
+++ b/www/core/sts/extension_sts.xml
@@ -20,29 +20,54 @@
 		<php_minimum>5.3.10</php_minimum>
 	</update>
 	<update>
-		<name>Joomla! 4.2</name>
-		<description>Joomla! 4.2 CMS</description>
+		<name>Joomla! 4.1</name>
+		<description>Joomla! 4.1 CMS</description>
 		<element>joomla</element>
 		<type>file</type>
-		<version>4.2.0</version>
-		<infourl title="Joomla 4.2.0 Release">https://www.joomla.org/announcements/release-news/5865-joomla-4-2-release.html</infourl>
+		<version>4.1.5</version>
+		<infourl title="Joomla 4.1.5 Release">https://www.joomla.org/announcements/release-news/5861-joomla-4-1-5-and-3-10-10-release.html</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://downloads.joomla.org/cms/joomla4/4-2-0/Joomla_4.2.0-Stable-Update_Package.zip</downloadurl>
-			<downloadsource type="full" format="zip">https://github.com/joomla/joomla-cms/releases/download/4.2.0/Joomla_4.2.0-Stable-Update_Package.zip</downloadsource>
-			<downloadsource type="full" format="zip">https://update.joomla.org/releases/4.2.0/Joomla_4.2.0-Stable-Update_Package.zip</downloadsource>
+			<downloadurl type="full" format="zip">https://downloads.joomla.org/cms/joomla4/4-1-5/Joomla_4.1.5-Stable-Update_Package.zip</downloadurl>
+			<downloadsource type="full" format="zip">https://github.com/joomla/joomla-cms/releases/download/4.1.5/Joomla_4.1.5-Stable-Update_Package.zip</downloadsource>
+			<downloadsource type="full" format="zip">https://update.joomla.org/releases/4.1.5/Joomla_4.1.5-Stable-Update_Package.zip</downloadsource>
 		</downloads>
 		<tags>
 			<tag>stable</tag>
 		</tags>
 		<supported_databases mysql="5.6" mariadb="10.1" postgresql="11.0" />
 		<php_minimum>7.2.5</php_minimum>
-		<sha256>c754870168f207a002f5ec297b3274ac5066be44f55bedf2b699c623d7c30f84</sha256>
-		<sha384>23ff1208e528520301235aa2d75330d440a978a85d099d8f7da0d23655a5c83236943c501bc4f3ad0404babe2e72cab3</sha384>
-		<sha512>8a3d9967e54f6047f9525a0d0f2d24b80a22e343f5a63ea3d18739e3faa2abcecb6103c7f3764009c46a21669489d812b84182385f5b9bc68a41c95708537c74</sha512>
+		<sha256>4ca1dcb9a603ceaa851a233c5232ace618239c5348d89b89966b47830e12f0b7</sha256>
+		<sha384>ece47292198066d2d9049d23175e4635857f326262b3a581196817086c723e631296bf30d2791999e171ddd7009b57ea</sha384>
+		<sha512>7d05270e83420ccd76b1f463d485358affb21357cc26e23a1ea18161cf2b354ccf601e80c64abce509280a052e1154f84a8c802bbcb7f4355ae35fe5b32921d2</sha512>
 		<maintainer>Joomla! Production Department</maintainer>
 		<maintainerurl>https://www.joomla.org</maintainerurl>
 		<section>STS</section>
 		<targetplatform name="joomla" version="3.10" />
+	</update>
+	<update>
+		<name>Joomla! 4.1</name>
+		<description>Joomla! 4.1 CMS</description>
+		<element>joomla</element>
+		<type>file</type>
+		<version>4.1.5</version>
+		<infourl title="Joomla 4.1.5 Release">https://www.joomla.org/announcements/release-news/5861-joomla-4-1-5-and-3-10-10-release.html</infourl>
+		<downloads>
+			<downloadurl type="full" format="zip">https://downloads.joomla.org/cms/joomla4/4-1-5/Joomla_4.1.5-Stable-Update_Package.zip</downloadurl>
+			<downloadsource type="full" format="zip">https://github.com/joomla/joomla-cms/releases/download/4.1.5/Joomla_4.1.5-Stable-Update_Package.zip</downloadsource>
+			<downloadsource type="full" format="zip">https://update.joomla.org/releases/4.1.5/Joomla_4.1.5-Stable-Update_Package.zip</downloadsource>
+		</downloads>
+		<tags>
+			<tag>stable</tag>
+		</tags>
+		<supported_databases mysql="5.6" mariadb="10.1" postgresql="11.0" />
+		<php_minimum>7.2.5</php_minimum>
+		<sha256>4ca1dcb9a603ceaa851a233c5232ace618239c5348d89b89966b47830e12f0b7</sha256>
+		<sha384>ece47292198066d2d9049d23175e4635857f326262b3a581196817086c723e631296bf30d2791999e171ddd7009b57ea</sha384>
+		<sha512>7d05270e83420ccd76b1f463d485358affb21357cc26e23a1ea18161cf2b354ccf601e80c64abce509280a052e1154f84a8c802bbcb7f4355ae35fe5b32921d2</sha512>
+		<maintainer>Joomla! Production Department</maintainer>
+		<maintainerurl>https://www.joomla.org</maintainerurl>
+		<section>STS</section>
+		<targetplatform name="joomla" version="4.[01]" />
 	</update>
 	<update>
 		<name>Joomla! 4.2</name>
@@ -51,7 +76,6 @@
 		<type>file</type>
 		<version>4.2.0</version>
 		<infourl title="Joomla 4.2.0 Release">https://www.joomla.org/announcements/release-news/5865-joomla-4-2-release.html</infourl>
-
 		<downloads>
 			<downloadurl type="full" format="zip">https://downloads.joomla.org/cms/joomla4/4-2-0/Joomla_4.2.0-Stable-Update_Package.zip</downloadurl>
 			<downloadsource type="full" format="zip">https://github.com/joomla/joomla-cms/releases/download/4.2.0/Joomla_4.2.0-Stable-Update_Package.zip</downloadsource>
@@ -68,6 +92,31 @@
 		<maintainer>Joomla! Production Department</maintainer>
 		<maintainerurl>https://www.joomla.org</maintainerurl>
 		<section>STS</section>
-		<targetplatform name="joomla" version="4.[012]" />
+		<targetplatform name="joomla" version="4.1.5" />
+	</update>
+	<update>
+		<name>Joomla! 4.2</name>
+		<description>Joomla! 4.2 CMS</description>
+		<element>joomla</element>
+		<type>file</type>
+		<version>4.2.0</version>
+		<infourl title="Joomla 4.2.0 Release">https://www.joomla.org/announcements/release-news/5865-joomla-4-2-release.html</infourl>
+		<downloads>
+			<downloadurl type="full" format="zip">https://downloads.joomla.org/cms/joomla4/4-2-0/Joomla_4.2.0-Stable-Update_Package.zip</downloadurl>
+			<downloadsource type="full" format="zip">https://github.com/joomla/joomla-cms/releases/download/4.2.0/Joomla_4.2.0-Stable-Update_Package.zip</downloadsource>
+			<downloadsource type="full" format="zip">https://update.joomla.org/releases/4.2.0/Joomla_4.2.0-Stable-Update_Package.zip</downloadsource>
+		</downloads>
+		<tags>
+			<tag>stable</tag>
+		</tags>
+		<supported_databases mysql="5.6" mariadb="10.1" postgresql="11.0" />
+		<php_minimum>7.2.5</php_minimum>
+		<sha256>c754870168f207a002f5ec297b3274ac5066be44f55bedf2b699c623d7c30f84</sha256>
+		<sha384>23ff1208e528520301235aa2d75330d440a978a85d099d8f7da0d23655a5c83236943c501bc4f3ad0404babe2e72cab3</sha384>
+		<sha512>8a3d9967e54f6047f9525a0d0f2d24b80a22e343f5a63ea3d18739e3faa2abcecb6103c7f3764009c46a21669489d812b84182385f5b9bc68a41c95708537c74</sha512>
+		<maintainer>Joomla! Production Department</maintainer>
+		<maintainerurl>https://www.joomla.org</maintainerurl>
+		<section>STS</section>
+		<targetplatform name="joomla" version="4.2" />
 	</update>
 </updates>

--- a/www/core/sts/list_sts.xml
+++ b/www/core/sts/list_sts.xml
@@ -15,7 +15,8 @@
 	<extension name="Joomla" element="joomla" type="file" version="3.10.11" targetplatformversion="3.9" detailsurl="https://update.joomla.org/core/extension.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="4.1.5" targetplatformversion="3.10.11" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="3.10.11" targetplatformversion="3.10" detailsurl="https://update.joomla.org/core/extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="4.2.0" targetplatformversion="4.0" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="4.2.0" targetplatformversion="4.1" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="4.1.5" targetplatformversion="4.0" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="4.1.5" targetplatformversion="4.1" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="4.2.0" targetplatformversion="4.1.5" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="4.2.0" targetplatformversion="4.2" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
 </extensionset>


### PR DESCRIPTION
cc @fancyFranci @roland-d that should force everyone to go via 4.1.5 and just when running 4.1.5 it can update to 4.2.0.