### PR TITLE
Nightlies do not target the right version

### DIFF
--- a/www/core/nightlies/next_major_extension.xml
+++ b/www/core/nightlies/next_major_extension.xml
@@ -23,7 +23,7 @@
 		<maintainer>Joomla! Production Department</maintainer>
 		<maintainerurl>https://www.joomla.org</maintainerurl>
 		<section>STS</section>
-		<targetplatform name="joomla" version="4.0" />
+		<targetplatform name="joomla" version="4.0.[123]" />
 	</update>
 	<update>
 		<name>Joomla! 5.0 Nightly Build</name>

--- a/www/core/nightlies/next_major_extension.xml
+++ b/www/core/nightlies/next_major_extension.xml
@@ -23,7 +23,7 @@
 		<maintainer>Joomla! Production Department</maintainer>
 		<maintainerurl>https://www.joomla.org</maintainerurl>
 		<section>STS</section>
-		<targetplatform name="joomla" version="4.0.[123]" />
+		<targetplatform name="joomla" version="4.0.[0123]" />
 	</update>
 	<update>
 		<name>Joomla! 5.0 Nightly Build</name>

--- a/www/core/nightlies/next_minor_extension.xml
+++ b/www/core/nightlies/next_minor_extension.xml
@@ -42,7 +42,7 @@
 		<maintainer>Joomla! Production Department</maintainer>
 		<maintainerurl>https://www.joomla.org</maintainerurl>
 		<section>STS</section>
-		<targetplatform name="joomla" version="4.0.[0-3]" />
+		<targetplatform name="joomla" version="4.0.[0123]" />
 	</update>
 	<update>
 		<name>Joomla! 4.3 Nightly Build</name>

--- a/www/core/nightlies/next_patch_extension.xml
+++ b/www/core/nightlies/next_patch_extension.xml
@@ -40,7 +40,7 @@
 		<maintainer>Joomla! Production Department</maintainer>
 		<maintainerurl>https://www.joomla.org</maintainerurl>
 		<section>STS</section>
-		<targetplatform name="joomla" version="4.0" />
+		<targetplatform name="joomla" version="4.0.[0123]" />
 	</update>
 	<update>
 		<name>Joomla! 4.2 Nightly Build</name>


### PR DESCRIPTION
There are 2 possibilities for sites coming from 4.0. 4.0 and 4.0.[4.5.6].
The first one is always the one used.