### PR TITLE
update to 5.x only with latest version of 4.x

### DIFF
--- a/www/core/nightlies/next_major_extension.xml
+++ b/www/core/nightlies/next_major_extension.xml
@@ -1,26 +1,6 @@
 <?xml version="1.0" ?>
 <updates>
 	<update>
-		<name>Joomla! 4.0</name>
-		<description>Joomla! 4.0 CMS</description>
-		<element>joomla</element>
-		<type>file</type>
-		<version>4.0.4</version>
-		<infourl title="Joomla 4.0.4 Release">https://www.joomla.org/announcements/release-news/5849-joomla-4-0-4-and-joomla-3-10-3-are-here.html</infourl>
-		<downloads>
-			<downloadurl type="full" format="zip">https://downloads.joomla.org/cms/joomla4/4-0-4/Joomla_4.0.4-Stable-Update_Package.zip</downloadurl>
-		</downloads>
-		<tags>
-			<tag>stable</tag>
-		</tags>
-		<supported_databases mysql="5.6" mariadb="10.1" postgresql="11.0" />
-		<php_minimum>7.2.5</php_minimum>
-		<maintainer>Joomla! Production Department</maintainer>
-		<maintainerurl>https://www.joomla.org</maintainerurl>
-		<section>STS</section>
-		<targetplatform name="joomla" version="4.0" />
-	</update>
-	<update>
 		<name>Joomla! 5.0 Nightly Build</name>
 		<description>Joomla! CMS</description>
 		<element>joomla</element>
@@ -37,26 +17,7 @@
 		<php_minimum>8.1.0</php_minimum>
 		<maintainer>Joomla! Production Department</maintainer>
 		<maintainerurl>https://www.joomla.org</maintainerurl>
-		<targetplatform name="joomla" version="4.0.[456]" />
-	</update>
-	<update>
-		<name>Joomla! 5.0 Nightly Build</name>
-		<description>Joomla! CMS</description>
-		<element>joomla</element>
-		<type>file</type>
-		<version>5.0.0-alpha2-dev</version>
-		<infourl title="Joomla! Nightly Builds">https://developer.joomla.org/nightly-builds.html</infourl>
-		<downloads>
-			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_5.0.0-alpha2-dev-Development-Update_Package.zip</downloadurl>
-		</downloads>
-		<tags>
-			<tag>stable</tag>
-		</tags>
-		<supported_databases mysql="8.0.11" mariadb="10.4.0" postgresql="12.0" />
-		<php_minimum>8.1.0</php_minimum>
-		<maintainer>Joomla! Production Department</maintainer>
-		<maintainerurl>https://www.joomla.org</maintainerurl>
-		<targetplatform name="joomla" version="4.[1234]" />
+		<targetplatform name="joomla" version="4.4" />
 	</update>
 	<update>
 		<name>Joomla! 5.0 Nightly Build</name>

--- a/www/core/nightlies/next_major_list.xml
+++ b/www/core/nightlies/next_major_list.xml
@@ -1,11 +1,4 @@
 <extensionset name="Joomla! Core Nightly Builds" description="Joomla! Core Next Major Nightly Builds">
-	<extension name="Joomla" element="joomla" type="file" version="5.0.0-alpha2-dev" targetplatformversion="4.0.4" detailsurl="https://update.joomla.org/core/nightlies/next_major_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="5.0.0-alpha2-dev" targetplatformversion="4.0.5" detailsurl="https://update.joomla.org/core/nightlies/next_major_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="5.0.0-alpha2-dev" targetplatformversion="4.0.6" detailsurl="https://update.joomla.org/core/nightlies/next_major_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="4.0.4" targetplatformversion="4.0" detailsurl="https://update.joomla.org/core/nightlies/next_major_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="5.0.0-alpha2-dev" targetplatformversion="4.1" detailsurl="https://update.joomla.org/core/nightlies/next_major_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="5.0.0-alpha2-dev" targetplatformversion="4.2" detailsurl="https://update.joomla.org/core/nightlies/next_major_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="5.0.0-alpha2-dev" targetplatformversion="4.3" detailsurl="https://update.joomla.org/core/nightlies/next_major_extension.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="5.0.0-alpha2-dev" targetplatformversion="4.4" detailsurl="https://update.joomla.org/core/nightlies/next_major_extension.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="5.0.0-alpha2-dev" targetplatformversion="5.0" detailsurl="https://update.joomla.org/core/nightlies/next_major_extension.xml" />
 </extensionset>


### PR DESCRIPTION
update to 5.x (nightlies) should be only possible with the latest version of 4.x (at the moment 4.4) due missing sql updates (or not removed files/folders) by `administrator/components/com_admin/script.php` when updating directly from 4.3 or earlier