### PR TITLE
Update MySQL version requirement for Joomla 5

### DIFF
--- a/www/core/nightlies/next_major_extension.xml
+++ b/www/core/nightlies/next_major_extension.xml
@@ -33,7 +33,7 @@
 		<tags>
 			<tag>stable</tag>
 		</tags>
-		<supported_databases mysql="8.0.11" mariadb="10.4.0" postgresql="12.0" />
+		<supported_databases mysql="8.0.13" mariadb="10.4.0" postgresql="12.0" />
 		<php_minimum>8.1.0</php_minimum>
 		<maintainer>Joomla! Production Department</maintainer>
 		<maintainerurl>https://www.joomla.org</maintainerurl>
@@ -52,7 +52,7 @@
 		<tags>
 			<tag>stable</tag>
 		</tags>
-		<supported_databases mysql="8.0.11" mariadb="10.4.0" postgresql="12.0" />
+		<supported_databases mysql="8.0.13" mariadb="10.4.0" postgresql="12.0" />
 		<php_minimum>8.1.0</php_minimum>
 		<maintainer>Joomla! Production Department</maintainer>
 		<maintainerurl>https://www.joomla.org</maintainerurl>
@@ -71,7 +71,7 @@
 		<tags>
 			<tag>stable</tag>
 		</tags>
-		<supported_databases mysql="8.0.11" mariadb="10.4" postgresql="12.0" />
+		<supported_databases mysql="8.0.13" mariadb="10.4.0" postgresql="12.0" />
 		<php_minimum>8.1.0</php_minimum>
 		<maintainer>Joomla! Production Department</maintainer>
 		<maintainerurl>https://www.joomla.org</maintainerurl>


### PR DESCRIPTION
The minimum MySQL version required for Joomla 5 has changed to 8.0.13, see https://github.com/joomla/joomla-cms/pull/40790#issuecomment-1600463050 .

This pull request adapts the update site of the 5.0 nightly builds to that changed requirement.

In addition, it aligns the minimum MariaDB version in line 35 to the same as in previous line 16.