### PR TITLE
Allow Update to 4 from 3.10.13

### DIFF
--- a/www/core/sts/list_sts.xml
+++ b/www/core/sts/list_sts.xml
@@ -13,7 +13,7 @@
 	<extension name="Joomla" element="joomla" type="file" version="3.10.12" targetplatformversion="3.7" detailsurl="https://update.joomla.org/core/extension.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="3.10.12" targetplatformversion="3.8" detailsurl="https://update.joomla.org/core/extension.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="3.10.12" targetplatformversion="3.9" detailsurl="https://update.joomla.org/core/extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="4.3.4" targetplatformversion="3.10.12" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="4.3.4" targetplatformversion="3.10.13" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="3.10.12" targetplatformversion="3.10" detailsurl="https://update.joomla.org/core/extension.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="4.3.4" targetplatformversion="4.0.4" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="4.3.4" targetplatformversion="4.0.5" detailsurl="https://update.joomla.org/core/sts/extension_sts.xml" />


### PR DESCRIPTION
Allow to update from [Joomla! ELTS](https://elts.joomla.org) version 3.10.13 to update to Joomla! 4