### PR TITLE
Update Channel Next J4.4 -> J5.0.x

### DIFF
--- a/www/core/sts/list_sts.xml
+++ b/www/core/sts/list_sts.xml
@@ -23,7 +23,7 @@
 	<extension name="Joomla" element="joomla" type="file" version="4.4.1" targetplatformversion="4.1" detailsurl="https://update.joomla.org/core/j4/default.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="4.4.1" targetplatformversion="4.2" detailsurl="https://update.joomla.org/core/j4/default.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="4.4.1" targetplatformversion="4.3" detailsurl="https://update.joomla.org/core/j4/default.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="5.0.1" targetplatformversion="4.4.0" detailsurl="https://update.joomla.org/core/j4/next.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.0.1" targetplatformversion="4.4.1" detailsurl="https://update.joomla.org/core/j4/next.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="4.4.1" targetplatformversion="4.4" detailsurl="https://update.joomla.org/core/j4/default.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="5.0.1" targetplatformversion="5.0" detailsurl="https://update.joomla.org/core/j5/next.xml" />
 </extensionset>


### PR DESCRIPTION
Update to J5.0.1 from J4.4 not possible
Follow up https://github.com/joomla/update.joomla.org/commit/f0ea86b26393028c83ddf2a883d0e03765a7f14b#

J4.4.0: Update Channel Next
![image](https://github.com/joomla/update.joomla.org/assets/66922325/b46e54dd-a35e-44f3-8819-b137a2291ae8)

J4.4.1: Update Channel Next
![image](https://github.com/joomla/update.joomla.org/assets/66922325/f8c0deb6-55c7-466d-a008-4eb500c04de5)
