### PR TITLE
Adapt nightly build XML files to versions 5.1, 5.2 and 6.0

### DIFF
--- a/www/core/nightlies/next_major_extension.xml
+++ b/www/core/nightlies/next_major_extension.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" ?>
 <updates>
 	<update>
-		<name>Joomla! 5.1 Nightly Build</name>
+		<name>Joomla! 6.0 Nightly Build</name>
 		<description>Joomla! CMS</description>
 		<element>joomla</element>
 		<type>file</type>
-		<version>5.1.1-dev</version>
+		<version>6.0.0-alpha1-dev</version>
 		<infourl title="Joomla! Nightly Builds">https://developer.joomla.org/nightly-builds.html</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_5.1.1-dev-Development-Update_Package.zip</downloadurl>
+			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_6.0.0-alpha1-dev-Development-Update_Package.zip</downloadurl>
 		</downloads>
 		<tags>
 			<tag>stable</tag>
@@ -17,17 +17,17 @@
 		<php_minimum>8.1.0</php_minimum>
 		<maintainer>Joomla! Production Department</maintainer>
 		<maintainerurl>https://www.joomla.org</maintainerurl>
-		<targetplatform name="joomla" version="4.4" />
+		<targetplatform name="joomla" version="5.2" />
 	</update>
 	<update>
-		<name>Joomla! 5.1 Nightly Build</name>
+		<name>Joomla! 6.0 Nightly Build</name>
 		<description>Joomla! CMS</description>
 		<element>joomla</element>
 		<type>file</type>
-		<version>5.1.1-dev</version>
+		<version>6.0.0-alpha1-dev</version>
 		<infourl title="Joomla! Nightly Builds">https://developer.joomla.org/nightly-builds.html</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_5.1.1-dev-Development-Update_Package.zip</downloadurl>
+			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_6.0.0-alpha1-dev-Development-Update_Package.zip</downloadurl>
 		</downloads>
 		<tags>
 			<tag>stable</tag>
@@ -36,6 +36,6 @@
 		<php_minimum>8.1.0</php_minimum>
 		<maintainer>Joomla! Production Department</maintainer>
 		<maintainerurl>https://www.joomla.org</maintainerurl>
-		<targetplatform name="joomla" version="5.0" />
+		<targetplatform name="joomla" version="6.0" />
 	</update>
 </updates>

--- a/www/core/nightlies/next_major_list.xml
+++ b/www/core/nightlies/next_major_list.xml
@@ -1,4 +1,4 @@
 <extensionset name="Joomla! Core Nightly Builds" description="Joomla! Core Next Major Nightly Builds">
-	<extension name="Joomla" element="joomla" type="file" version="5.1.1-dev" targetplatformversion="4.4" detailsurl="https://update.joomla.org/core/nightlies/next_major_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="5.1.1-dev" targetplatformversion="5.0" detailsurl="https://update.joomla.org/core/nightlies/next_major_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="6.0.0-alpha1-dev" targetplatformversion="5.2" detailsurl="https://update.joomla.org/core/nightlies/next_major_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="6.0.0-alpha1-dev" targetplatformversion="6.0" detailsurl="https://update.joomla.org/core/nightlies/next_major_extension.xml" />
 </extensionset>

--- a/www/core/nightlies/next_minor_extension.xml
+++ b/www/core/nightlies/next_minor_extension.xml
@@ -1,91 +1,14 @@
 <?xml version="1.0" ?>
 <updates>
 	<update>
-		<name>Joomla! 4.4 Nightly Build</name>
+		<name>Joomla! 5.2 Nightly Build</name>
 		<description>Joomla! CMS</description>
 		<element>joomla</element>
 		<type>file</type>
-		<version>4.4.5-dev</version>
+		<version>5.2.0-alpha2-dev</version>
 		<infourl title="Joomla! Nightly Builds">https://developer.joomla.org/nightly-builds.html</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_4.4.5-dev-Development-Update_Package.zip</downloadurl>
-		</downloads>
-		<tags>
-			<tag>stable</tag>
-		</tags>
-		<supported_databases mysql="5.6" mariadb="10.1" postgresql="11.0" />
-		<php_minimum>7.2.5</php_minimum>
-		<maintainer>Joomla! Production Department</maintainer>
-		<maintainerurl>https://www.joomla.org</maintainerurl>
-		<targetplatform name="joomla" version="3.10" />
-	</update>
-	<update>
-		<name>Joomla! 4.0</name>
-		<description>Joomla! 4.0 CMS</description>
-		<element>joomla</element>
-		<type>file</type>
-		<version>4.0.4</version>
-		<infourl title="Joomla 4.0.4 Release">https://www.joomla.org/announcements/release-news/5849-joomla-4-0-4-and-joomla-3-10-3-are-here.html</infourl>
-		<downloads>
-			<downloadurl type="full" format="zip">https://downloads.joomla.org/cms/joomla4/4-0-4/Joomla_4.0.4-Stable-Update_Package.zip</downloadurl>
-		</downloads>
-		<tags>
-			<tag>stable</tag>
-		</tags>
-		<supported_databases mysql="5.6" mariadb="10.1" postgresql="11.0" />
-		<php_minimum>7.2.5</php_minimum>
-		<maintainer>Joomla! Production Department</maintainer>
-		<maintainerurl>https://www.joomla.org</maintainerurl>
-		<section>STS</section>
-		<targetplatform name="joomla" version="4.0" />
-	</update>
-	<update>
-		<name>Joomla! 4.4 Nightly Build</name>
-		<description>Joomla! CMS</description>
-		<element>joomla</element>
-		<type>file</type>
-		<version>4.4.5-dev</version>
-		<infourl title="Joomla! Nightly Builds">https://developer.joomla.org/nightly-builds.html</infourl>
-		<downloads>
-			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_4.4.5-dev-Development-Update_Package.zip</downloadurl>
-		</downloads>
-		<tags>
-			<tag>stable</tag>
-		</tags>
-		<supported_databases mysql="5.6" mariadb="10.1" postgresql="11.0" />
-		<php_minimum>7.2.5</php_minimum>
-		<maintainer>Joomla! Production Department</maintainer>
-		<maintainerurl>https://www.joomla.org</maintainerurl>
-		<targetplatform name="joomla" version="4.0.[456]" />
-	</update>
-	<update>
-		<name>Joomla! 4.4 Nightly Build</name>
-		<description>Joomla! CMS</description>
-		<element>joomla</element>
-		<type>file</type>
-		<version>4.4.5-dev</version>
-		<infourl title="Joomla! Nightly Builds">https://developer.joomla.org/nightly-builds.html</infourl>
-		<downloads>
-			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_4.4.5-dev-Development-Update_Package.zip</downloadurl>
-		</downloads>
-		<tags>
-			<tag>stable</tag>
-		</tags>
-		<supported_databases mysql="5.6" mariadb="10.1" postgresql="11.0" />
-		<php_minimum>7.2.5</php_minimum>
-		<maintainer>Joomla! Production Department</maintainer>
-		<maintainerurl>https://www.joomla.org</maintainerurl>
-		<targetplatform name="joomla" version="4.[1234]" />
-	</update>
-	<update>
-		<name>Joomla! 5.1 Nightly Build</name>
-		<description>Joomla! CMS</description>
-		<element>joomla</element>
-		<type>file</type>
-		<version>5.1.1-dev</version>
-		<infourl title="Joomla! Nightly Builds">https://developer.joomla.org/nightly-builds.html</infourl>
-		<downloads>
-			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_5.1.1-dev-Development-Update_Package.zip</downloadurl>
+			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_5.2.0-alpha2-dev-Development-Update_Package.zip</downloadurl>
 		</downloads>
 		<tags>
 			<tag>stable</tag>
@@ -94,6 +17,25 @@
 		<php_minimum>8.1.0</php_minimum>
 		<maintainer>Joomla! Production Department</maintainer>
 		<maintainerurl>https://www.joomla.org</maintainerurl>
-		<targetplatform name="joomla" version="5.[0]" />
+		<targetplatform name="joomla" version="4.4.[56]" />
+	</update>
+	<update>
+		<name>Joomla! 5.2 Nightly Build</name>
+		<description>Joomla! CMS</description>
+		<element>joomla</element>
+		<type>file</type>
+		<version>5.2.0-alpha2-dev</version>
+		<infourl title="Joomla! Nightly Builds">https://developer.joomla.org/nightly-builds.html</infourl>
+		<downloads>
+			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_5.2.0-alpha2-dev-Development-Update_Package.zip</downloadurl>
+		</downloads>
+		<tags>
+			<tag>stable</tag>
+		</tags>
+		<supported_databases mysql="8.0.13" mariadb="10.4" postgresql="12.0" />
+		<php_minimum>8.1.0</php_minimum>
+		<maintainer>Joomla! Production Department</maintainer>
+		<maintainerurl>https://www.joomla.org</maintainerurl>
+		<targetplatform name="joomla" version="5.[012]" />
 	</update>
 </updates>

--- a/www/core/nightlies/next_minor_list.xml
+++ b/www/core/nightlies/next_minor_list.xml
@@ -1,12 +1,7 @@
 <extensionset name="Joomla! Core Nightly Builds" description="Joomla! Core Next Minor Nightly Builds">
-	<extension name="Joomla" element="joomla" type="file" version="4.4.5-dev" targetplatformversion="3.10" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="4.4.5-dev" targetplatformversion="4.0.4" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="4.4.5-dev" targetplatformversion="4.0.5" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="4.4.5-dev" targetplatformversion="4.0.6" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="4.0.4" targetplatformversion="4.0" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="4.4.5-dev" targetplatformversion="4.1" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="4.4.5-dev" targetplatformversion="4.2" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="4.4.5-dev" targetplatformversion="4.3" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="4.4.5-dev" targetplatformversion="4.4" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="5.1.1-dev" targetplatformversion="5.0" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.2.0-alpha2-dev" targetplatformversion="4.4.5" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.2.0-alpha2-dev" targetplatformversion="4.4.6" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.2.0-alpha2-dev" targetplatformversion="5.0" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.2.0-alpha2-dev" targetplatformversion="5.1" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.2.0-alpha2-dev" targetplatformversion="5.2" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
 </extensionset>

--- a/www/core/nightlies/next_patch_extension.xml
+++ b/www/core/nightlies/next_patch_extension.xml
@@ -1,6 +1,25 @@
 <?xml version="1.0" ?>
 <updates>
 	<update>
+		<name>Joomla! 4.4 Nightly Build</name>
+		<description>Joomla! CMS</description>
+		<element>joomla</element>
+		<type>file</type>
+		<version>4.4.6-dev</version>
+		<infourl title="Joomla! Nightly Builds">https://developer.joomla.org/nightly-builds.html</infourl>
+		<downloads>
+			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_4.4.6-dev-Development-Update_Package.zip</downloadurl>
+		</downloads>
+		<tags>
+			<tag>stable</tag>
+		</tags>
+		<supported_databases mysql="5.6" mariadb="10.1" postgresql="11.0" />
+		<php_minimum>7.2.5</php_minimum>
+		<maintainer>Joomla! Production Department</maintainer>
+		<maintainerurl>https://www.joomla.org</maintainerurl>
+		<targetplatform name="joomla" version="3.10" />
+	</update>
+	<update>
 		<name>Joomla! 4.0</name>
 		<description>Joomla! 4.0 CMS</description>
 		<element>joomla</element>
@@ -25,10 +44,10 @@
 		<description>Joomla! CMS</description>
 		<element>joomla</element>
 		<type>file</type>
-		<version>4.4.5-dev</version>
+		<version>4.4.6-dev</version>
 		<infourl title="Joomla! Nightly Builds">https://developer.joomla.org/nightly-builds.html</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_4.4.5-dev-Development-Update_Package.zip</downloadurl>
+			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_4.4.6-dev-Development-Update_Package.zip</downloadurl>
 		</downloads>
 		<tags>
 			<tag>stable</tag>
@@ -44,10 +63,10 @@
 		<description>Joomla! CMS</description>
 		<element>joomla</element>
 		<type>file</type>
-		<version>4.4.5-dev</version>
+		<version>4.4.6-dev</version>
 		<infourl title="Joomla! Nightly Builds">https://developer.joomla.org/nightly-builds.html</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_4.4.5-dev-Development-Update_Package.zip</downloadurl>
+			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_4.4.6-dev-Development-Update_Package.zip</downloadurl>
 		</downloads>
 		<tags>
 			<tag>stable</tag>
@@ -63,10 +82,10 @@
 		<description>Joomla! CMS</description>
 		<element>joomla</element>
 		<type>file</type>
-		<version>5.1.1-dev</version>
+		<version>5.1.2-dev</version>
 		<infourl title="Joomla! Nightly Builds">https://developer.joomla.org/nightly-builds.html</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_5.1.1-dev-Development-Update_Package.zip</downloadurl>
+			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_5.1.2-dev-Development-Update_Package.zip</downloadurl>
 		</downloads>
 		<tags>
 			<tag>stable</tag>
@@ -75,6 +94,25 @@
 		<php_minimum>8.1.0</php_minimum>
 		<maintainer>Joomla! Production Department</maintainer>
 		<maintainerurl>https://www.joomla.org</maintainerurl>
-		<targetplatform name="joomla" version="5.[0]" />
+		<targetplatform name="joomla" version="4.4.[56]" />
+	</update>
+	<update>
+		<name>Joomla! 5.1 Nightly Build</name>
+		<description>Joomla! CMS</description>
+		<element>joomla</element>
+		<type>file</type>
+		<version>5.1.2-dev</version>
+		<infourl title="Joomla! Nightly Builds">https://developer.joomla.org/nightly-builds.html</infourl>
+		<downloads>
+			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_5.1.2-dev-Development-Update_Package.zip</downloadurl>
+		</downloads>
+		<tags>
+			<tag>stable</tag>
+		</tags>
+		<supported_databases mysql="8.0.13" mariadb="10.4" postgresql="12.0" />
+		<php_minimum>8.1.0</php_minimum>
+		<maintainer>Joomla! Production Department</maintainer>
+		<maintainerurl>https://www.joomla.org</maintainerurl>
+		<targetplatform name="joomla" version="5.[01]" />
 	</update>
 </updates>

--- a/www/core/nightlies/next_patch_list.xml
+++ b/www/core/nightlies/next_patch_list.xml
@@ -1,11 +1,15 @@
 <extensionset name="Joomla! Core Nightly Builds" description="Joomla! Core Next Patch Nightly Builds">
-	<extension name="Joomla" element="joomla" type="file" version="4.4.5-dev" targetplatformversion="4.0.4" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="4.4.5-dev" targetplatformversion="4.0.5" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="4.4.5-dev" targetplatformversion="4.0.6" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="4.4.6-dev" targetplatformversion="3.10" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="4.4.6-dev" targetplatformversion="4.0.4" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="4.4.6-dev" targetplatformversion="4.0.5" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="4.4.6-dev" targetplatformversion="4.0.6" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="4.0.4" targetplatformversion="4.0" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="4.4.5-dev" targetplatformversion="4.1" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="4.4.5-dev" targetplatformversion="4.2" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="4.4.5-dev" targetplatformversion="4.3" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="4.4.5-dev" targetplatformversion="4.4" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="5.1.1-dev" targetplatformversion="5.0" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="4.4.6-dev" targetplatformversion="4.1" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="4.4.6-dev" targetplatformversion="4.2" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="4.4.6-dev" targetplatformversion="4.3" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.1.2-dev" targetplatformversion="4.4.5" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.1.2-dev" targetplatformversion="4.4.6" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="4.4.6-dev" targetplatformversion="4.4" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.1.2-dev" targetplatformversion="5.0" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.1.2-dev" targetplatformversion="5.1" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
 </extensionset>


### PR DESCRIPTION
Pull request for CMS issue https://github.com/joomla/joomla-cms/issues/43643 .

This pull request (PR) adapts the nightly build XML files to versions 5.1, 5.2 and 6.0.

Currently they are outdated as there is no update path to 6.0 or 5.2 nightlies, and the 5.1 path is outdated.

Therefore on https://developer.joomla.org/nightly-builds.html there is shown a custom update URL only for the 4.4 but not for the 5.1, 5.2 and 6.0 nightlies.

The reason is that the assignment to next_patch, next_minor and next_major has not been updated after 5.0 became outdated.

This PR here fixes that by updating the XML files so that
- The "next_patch" files are used for updating to the latest 4.4 or 5.1 nightly build.
You have to be on the latest 4.4 stable release (currently 4.4.5) or the latest 4.4 nightly build (currently 4.4.6-dev) to find an update to the 5.1 nightly.
For previous versions back to 3.10 the files contain all necessary intermediate update steps.
For this purpose the update from 3.10 to 4.4 nightly has been moved from the "next_minor" files to "next_patch".
When 5.2 stable will be released, the "next_patch" files have to be updated to replace 5.1 by 5.2. 

- "next_minor" is used for updating to the latest 5.2 nightly build.
You have to be on the latest 4.4 stable release (currently 4.4.5) or the latest 4.4 nightly build (currently 4.4.6-dev) or on any 5.x version or nightly to find an update to the 5.2 nightly.
When 5.2 stable will be released, the "next_minor" files have to be updated so 5.3 will be the next minor. 

- "next_major" is used for updating to the latest 6.0 nightly build.
You have to be on a 5.2 or 6.0 (currently both alpha or nightly) to find an update to the 6.0 nightly.
The 5.x requirement will be increased with each new 5.x minor version until the final one is reached.

When this PR will be merged, the custom update server URLs on https://developer.joomla.org/nightly-builds.html have to be adapted or added back:
- For both the 4.4 and 5.1 nightlies use https://update.joomla.org/core/nightlies/next_patch_list.xml
- For the 5.2 nightlies use https://update.joomla.org/core/nightlies/next_minor_list.xml
- For the 6.0 nightlies use https://update.joomla.org/core/nightlies/next_major_list.xml

For this purpose I've created a PR there: https://github.com/joomla/developer.joomla.org/pull/54

An alternative to this PR could be to get rid of the historically grown naming scheme and name the files with "major.minor" version in the same way as they are linked on https://developer.joomla.org/nightly-builds.html. Based on this PR here it would mean that "next_major" files would be renamed to "6.0", "next_minor" files would be renamed to "5.2" and "next_patch" files would be split into separate files "4.4" and "5.1".