### PR TITLE
Update nightlies next minor to 5.2.0-alpha3-dev

### DIFF
--- a/www/core/nightlies/next_minor_extension.xml
+++ b/www/core/nightlies/next_minor_extension.xml
@@ -17,7 +17,7 @@
 		<php_minimum>8.1.0</php_minimum>
 		<maintainer>Joomla! Production Department</maintainer>
 		<maintainerurl>https://www.joomla.org</maintainerurl>
-		<targetplatform name="joomla" version="4.4.[56]" />
+		<targetplatform name="joomla" version="4.4.[67]" />
 	</update>
 	<update>
 		<name>Joomla! 5.2 Nightly Build</name>

--- a/www/core/nightlies/next_minor_extension.xml
+++ b/www/core/nightlies/next_minor_extension.xml
@@ -5,10 +5,10 @@
 		<description>Joomla! CMS</description>
 		<element>joomla</element>
 		<type>file</type>
-		<version>5.2.0-alpha2-dev</version>
+		<version>5.2.0-alpha3-dev</version>
 		<infourl title="Joomla! Nightly Builds">https://developer.joomla.org/nightly-builds.html</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_5.2.0-alpha2-dev-Development-Update_Package.zip</downloadurl>
+			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_5.2.0-alpha3-dev-Development-Update_Package.zip</downloadurl>
 		</downloads>
 		<tags>
 			<tag>stable</tag>
@@ -24,10 +24,10 @@
 		<description>Joomla! CMS</description>
 		<element>joomla</element>
 		<type>file</type>
-		<version>5.2.0-alpha2-dev</version>
+		<version>5.2.0-alpha3-dev</version>
 		<infourl title="Joomla! Nightly Builds">https://developer.joomla.org/nightly-builds.html</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_5.2.0-alpha2-dev-Development-Update_Package.zip</downloadurl>
+			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_5.2.0-alpha3-dev-Development-Update_Package.zip</downloadurl>
 		</downloads>
 		<tags>
 			<tag>stable</tag>

--- a/www/core/nightlies/next_minor_list.xml
+++ b/www/core/nightlies/next_minor_list.xml
@@ -1,6 +1,6 @@
 <extensionset name="Joomla! Core Nightly Builds" description="Joomla! Core Next Minor Nightly Builds">
-	<extension name="Joomla" element="joomla" type="file" version="5.2.0-alpha3-dev" targetplatformversion="4.4.5" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="5.2.0-alpha3-dev" targetplatformversion="4.4.6" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.2.0-alpha3-dev" targetplatformversion="4.4.7" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="5.2.0-alpha3-dev" targetplatformversion="5.0" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="5.2.0-alpha3-dev" targetplatformversion="5.1" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="5.2.0-alpha3-dev" targetplatformversion="5.2" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />

--- a/www/core/nightlies/next_minor_list.xml
+++ b/www/core/nightlies/next_minor_list.xml
@@ -1,7 +1,7 @@
 <extensionset name="Joomla! Core Nightly Builds" description="Joomla! Core Next Minor Nightly Builds">
-	<extension name="Joomla" element="joomla" type="file" version="5.2.0-alpha2-dev" targetplatformversion="4.4.5" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="5.2.0-alpha2-dev" targetplatformversion="4.4.6" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="5.2.0-alpha2-dev" targetplatformversion="5.0" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="5.2.0-alpha2-dev" targetplatformversion="5.1" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="5.2.0-alpha2-dev" targetplatformversion="5.2" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.2.0-alpha3-dev" targetplatformversion="4.4.5" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.2.0-alpha3-dev" targetplatformversion="4.4.6" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.2.0-alpha3-dev" targetplatformversion="5.0" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.2.0-alpha3-dev" targetplatformversion="5.1" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.2.0-alpha3-dev" targetplatformversion="5.2" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
 </extensionset>


### PR DESCRIPTION
Update nightly builds next minor XML files to 5.2.0-alpha3-dev.

Should have been done after the  5.2.0-alpha2 release.

Update 2024-07-09: Updated to targetplatforms 4.4.6 and 4.4.7(-dev) after 4.4.6 release.