### PR TITLE
Adjust nightly build update sites for next minor and next major to 5.3

### DIFF
--- a/www/core/nightlies/next_major_extension.xml
+++ b/www/core/nightlies/next_major_extension.xml
@@ -17,7 +17,7 @@
 		<php_minimum>8.1.0</php_minimum>
 		<maintainer>Joomla! Production Department</maintainer>
 		<maintainerurl>https://www.joomla.org</maintainerurl>
-		<targetplatform name="joomla" version="5.2" />
+		<targetplatform name="joomla" version="5.3" />
 	</update>
 	<update>
 		<name>Joomla! 6.0 Nightly Build</name>

--- a/www/core/nightlies/next_major_list.xml
+++ b/www/core/nightlies/next_major_list.xml
@@ -1,4 +1,4 @@
 <extensionset name="Joomla! Core Nightly Builds" description="Joomla! Core Next Major Nightly Builds">
-	<extension name="Joomla" element="joomla" type="file" version="6.0.0-alpha1-dev" targetplatformversion="5.2" detailsurl="https://update.joomla.org/core/nightlies/next_major_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="6.0.0-alpha1-dev" targetplatformversion="5.3" detailsurl="https://update.joomla.org/core/nightlies/next_major_extension.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="6.0.0-alpha1-dev" targetplatformversion="6.0" detailsurl="https://update.joomla.org/core/nightlies/next_major_extension.xml" />
 </extensionset>

--- a/www/core/nightlies/next_minor_extension.xml
+++ b/www/core/nightlies/next_minor_extension.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" ?>
 <updates>
 	<update>
-		<name>Joomla! 5.2 Nightly Build</name>
+		<name>Joomla! 5.3 Nightly Build</name>
 		<description>Joomla! CMS</description>
 		<element>joomla</element>
 		<type>file</type>
-		<version>5.2.1-dev</version>
+		<version>5.3.0-alpha1-dev</version>
 		<infourl title="Joomla! Nightly Builds">https://developer.joomla.org/nightly-builds.html</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_5.2.1-dev-Development-Update_Package.zip</downloadurl>
+			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_5.3.0-alpha1-dev-Development-Update_Package.zip</downloadurl>
 		</downloads>
 		<tags>
 			<tag>stable</tag>
@@ -20,14 +20,14 @@
 		<targetplatform name="joomla" version="4.4.(9|(1[0]))" />
 	</update>
 	<update>
-		<name>Joomla! 5.2 Nightly Build</name>
+		<name>Joomla! 5.3 Nightly Build</name>
 		<description>Joomla! CMS</description>
 		<element>joomla</element>
 		<type>file</type>
-		<version>5.2.1-dev</version>
+		<version>5.3.0-alpha1-dev</version>
 		<infourl title="Joomla! Nightly Builds">https://developer.joomla.org/nightly-builds.html</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_5.2.1-dev-Development-Update_Package.zip</downloadurl>
+			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_5.3.0-alpha1-dev-Development-Update_Package.zip</downloadurl>
 		</downloads>
 		<tags>
 			<tag>stable</tag>

--- a/www/core/nightlies/next_minor_list.xml
+++ b/www/core/nightlies/next_minor_list.xml
@@ -1,7 +1,7 @@
 <extensionset name="Joomla! Core Nightly Builds" description="Joomla! Core Next Minor Nightly Builds">
-	<extension name="Joomla" element="joomla" type="file" version="5.2.1-dev" targetplatformversion="4.4.9" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="5.2.1-dev" targetplatformversion="4.4.10" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="5.2.1-dev" targetplatformversion="5.0" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="5.2.1-dev" targetplatformversion="5.1" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="5.2.1-dev" targetplatformversion="5.2" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.3.0-alpha1-dev" targetplatformversion="4.4.9" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.3.0-alpha1-dev" targetplatformversion="4.4.10" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.3.0-alpha1-dev" targetplatformversion="5.0" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.3.0-alpha1-dev" targetplatformversion="5.1" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.3.0-alpha1-dev" targetplatformversion="5.2" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
 </extensionset>


### PR DESCRIPTION
Now as PR https://github.com/joomla/developer.joomla.org/pull/55 for the content plugin has been merged and deployed, the custom update URLs shown at https://developer.joomla.org/nightly-builds.html .

- Next patch is for updating to 4.4 and 5.2 nightlies.
- Next minor is for updating to 5.3 nightlies.
- Next major is for updating to 6.0 nightlies.

But the update site XML files for the nightlies still use 5.2 as the next minor.

This pull request here adapts the next minor so updates to 5.3 nightly builds will be found.

It also updates next major so it requires to be at the latest 5.3 nightly before you can update to 6.0 nightly.