### PR TITLE
Allow to update to 6.0 nightly also from 5.4

### DIFF
--- a/www/core/nightlies/next_major_extension.xml
+++ b/www/core/nightlies/next_major_extension.xml
@@ -17,7 +17,7 @@
 		<php_minimum>8.1.0</php_minimum>
 		<maintainer>Joomla! Production Department</maintainer>
 		<maintainerurl>https://www.joomla.org</maintainerurl>
-		<targetplatform name="joomla" version="5.3" />
+		<targetplatform name="joomla" version="5.[34]" />
 	</update>
 	<update>
 		<name>Joomla! 6.0 Nightly Build</name>

--- a/www/core/nightlies/next_major_list.xml
+++ b/www/core/nightlies/next_major_list.xml
@@ -1,4 +1,5 @@
 <extensionset name="Joomla! Core Nightly Builds" description="Joomla! Core Next Major Nightly Builds">
 	<extension name="Joomla" element="joomla" type="file" version="6.0.0-alpha1-dev" targetplatformversion="5.3" detailsurl="https://update.joomla.org/core/nightlies/next_major_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="6.0.0-alpha1-dev" targetplatformversion="5.4" detailsurl="https://update.joomla.org/core/nightlies/next_major_extension.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="6.0.0-alpha1-dev" targetplatformversion="6.0" detailsurl="https://update.joomla.org/core/nightlies/next_major_extension.xml" />
 </extensionset>


### PR DESCRIPTION
Testing updates to 6.0 nightly build using the custom update URL should also be possible from a current 5.4-dev branch or a 5.4-dev nightly build.

As long as there are no 5.4-specific update SQL scripts, we can keep also 5.3 as targetplatform version.