### PR TITLE
Change nightly build next minor to 5.4 and next patch to 5.3

### DIFF
--- a/www/core/nightlies/next_minor_extension.xml
+++ b/www/core/nightlies/next_minor_extension.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" ?>
 <updates>
 	<update>
-		<name>Joomla! 5.3 Nightly Build</name>
+		<name>Joomla! 5.4 Nightly Build</name>
 		<description>Joomla! CMS</description>
 		<element>joomla</element>
 		<type>file</type>
-		<version>5.3.0-rc3-dev</version>
+		<version>5.4.0-alpha1-dev</version>
 		<infourl title="Joomla! Nightly Builds">https://developer.joomla.org/nightly-builds.html</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_5.3.0-rc3-dev-Development-Update_Package.zip</downloadurl>
+			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_5.4.0-alpha1-dev-Development-Update_Package.zip</downloadurl>
 		</downloads>
 		<tags>
 			<tag>stable</tag>
@@ -20,14 +20,14 @@
 		<targetplatform name="joomla" version="4.4.1[34]" />
 	</update>
 	<update>
-		<name>Joomla! 5.3 Nightly Build</name>
+		<name>Joomla! 5.4 Nightly Build</name>
 		<description>Joomla! CMS</description>
 		<element>joomla</element>
 		<type>file</type>
-		<version>5.3.0-rc3-dev</version>
+		<version>5.4.0-alpha1-dev</version>
 		<infourl title="Joomla! Nightly Builds">https://developer.joomla.org/nightly-builds.html</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_5.3.0-rc3-dev-Development-Update_Package.zip</downloadurl>
+			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_5.4.0-alpha1-dev-Development-Update_Package.zip</downloadurl>
 		</downloads>
 		<tags>
 			<tag>stable</tag>
@@ -36,6 +36,6 @@
 		<php_minimum>8.1.0</php_minimum>
 		<maintainer>Joomla! Production Department</maintainer>
 		<maintainerurl>https://www.joomla.org</maintainerurl>
-		<targetplatform name="joomla" version="5.[0123]" />
+		<targetplatform name="joomla" version="5.[01234]" />
 	</update>
 </updates>

--- a/www/core/nightlies/next_minor_list.xml
+++ b/www/core/nightlies/next_minor_list.xml
@@ -1,8 +1,9 @@
 <extensionset name="Joomla! Core Nightly Builds" description="Joomla! Core Next Minor Nightly Builds">
-	<extension name="Joomla" element="joomla" type="file" version="5.3.0-rc3-dev" targetplatformversion="4.4.13" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="5.3.0-rc3-dev" targetplatformversion="4.4.14" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="5.3.0-rc3-dev" targetplatformversion="5.0" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="5.3.0-rc3-dev" targetplatformversion="5.1" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="5.3.0-rc3-dev" targetplatformversion="5.2" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="5.3.0-rc3-dev" targetplatformversion="5.3" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.4.0-alpha1-dev" targetplatformversion="4.4.13" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.4.0-alpha1-dev" targetplatformversion="4.4.14" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.4.0-alpha1-dev" targetplatformversion="5.0" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.4.0-alpha1-dev" targetplatformversion="5.1" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.4.0-alpha1-dev" targetplatformversion="5.2" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.4.0-alpha1-dev" targetplatformversion="5.3" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.4.0-alpha1-dev" targetplatformversion="5.4" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
 </extensionset>

--- a/www/core/nightlies/next_patch_extension.xml
+++ b/www/core/nightlies/next_patch_extension.xml
@@ -78,14 +78,14 @@
 		<targetplatform name="joomla" version="4.[1234]" />
 	</update>
 	<update>
-		<name>Joomla! 5.2 Nightly Build</name>
+		<name>Joomla! 5.3 Nightly Build</name>
 		<description>Joomla! CMS</description>
 		<element>joomla</element>
 		<type>file</type>
-		<version>5.2.7-dev</version>
+		<version>5.3.1-dev</version>
 		<infourl title="Joomla! Nightly Builds">https://developer.joomla.org/nightly-builds.html</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_5.2.7-dev-Development-Update_Package.zip</downloadurl>
+			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_5.3.1-dev-Development-Update_Package.zip</downloadurl>
 		</downloads>
 		<tags>
 			<tag>stable</tag>
@@ -94,17 +94,17 @@
 		<php_minimum>8.1.0</php_minimum>
 		<maintainer>Joomla! Production Department</maintainer>
 		<maintainerurl>https://www.joomla.org</maintainerurl>
-		<targetplatform name="joomla" version="4.4.(1[1234])" />
+		<targetplatform name="joomla" version="4.4.(1[34])" />
 	</update>
 	<update>
-		<name>Joomla! 5.2 Nightly Build</name>
+		<name>Joomla! 5.3 Nightly Build</name>
 		<description>Joomla! CMS</description>
 		<element>joomla</element>
 		<type>file</type>
-		<version>5.2.7-dev</version>
+		<version>5.3.1-dev</version>
 		<infourl title="Joomla! Nightly Builds">https://developer.joomla.org/nightly-builds.html</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_5.2.7-dev-Development-Update_Package.zip</downloadurl>
+			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_5.3.1-dev-Development-Update_Package.zip</downloadurl>
 		</downloads>
 		<tags>
 			<tag>stable</tag>
@@ -113,6 +113,6 @@
 		<php_minimum>8.1.0</php_minimum>
 		<maintainer>Joomla! Production Department</maintainer>
 		<maintainerurl>https://www.joomla.org</maintainerurl>
-		<targetplatform name="joomla" version="5.[012]" />
+		<targetplatform name="joomla" version="5.[0123]" />
 	</update>
 </updates>

--- a/www/core/nightlies/next_patch_list.xml
+++ b/www/core/nightlies/next_patch_list.xml
@@ -7,9 +7,10 @@
 	<extension name="Joomla" element="joomla" type="file" version="4.4.14-dev" targetplatformversion="4.1" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="4.4.14-dev" targetplatformversion="4.2" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="4.4.14-dev" targetplatformversion="4.3" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="5.2.7-dev" targetplatformversion="4.4.14" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.3.1-dev" targetplatformversion="4.4.14" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="4.4.14-dev" targetplatformversion="4.4" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="5.2.7-dev" targetplatformversion="5.0" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="5.2.7-dev" targetplatformversion="5.1" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="5.2.7-dev" targetplatformversion="5.2" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.3.1-dev" targetplatformversion="5.0" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.3.1-dev" targetplatformversion="5.1" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.3.1-dev" targetplatformversion="5.2" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.3.1-dev" targetplatformversion="5.3" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
 </extensionset>

--- a/www/core/nightlies/next_patch_list.xml
+++ b/www/core/nightlies/next_patch_list.xml
@@ -7,6 +7,7 @@
 	<extension name="Joomla" element="joomla" type="file" version="4.4.14-dev" targetplatformversion="4.1" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="4.4.14-dev" targetplatformversion="4.2" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="4.4.14-dev" targetplatformversion="4.3" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.3.1-dev" targetplatformversion="4.4.13" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="5.3.1-dev" targetplatformversion="4.4.14" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="4.4.14-dev" targetplatformversion="4.4" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="5.3.1-dev" targetplatformversion="5.0" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />


### PR DESCRIPTION
This pull request (PR) changes the next minor nightly builds from 5.3 to 5.4 and the next patch nightly builds to 5.3.

### It has to be merged AFTER the release of 5.3.0 stable on Tuesday, April 15.

When this PR here has been merged, PR https://github.com/joomla/developer.joomla.org/pull/56 for the "nightlybuilds" content plugin has to be merged, too, and that plugin has to be published to `developer.joomla.org`.