### PR TITLE
Update nightlies after 5.4.0 alpha1 and 6.0.0 alpha1 releases

### DIFF
--- a/www/core/nightlies/next_major_extension.xml
+++ b/www/core/nightlies/next_major_extension.xml
@@ -5,10 +5,10 @@
 		<description>Joomla! CMS</description>
 		<element>joomla</element>
 		<type>file</type>
-		<version>6.0.0-alpha1-dev</version>
+		<version>6.0.0-alpha2-dev</version>
 		<infourl title="Joomla! Nightly Builds">https://developer.joomla.org/nightly-builds.html</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_6.0.0-alpha1-dev-Development-Update_Package.zip</downloadurl>
+			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_6.0.0-alpha2-dev-Development-Update_Package.zip</downloadurl>
 		</downloads>
 		<tags>
 			<tag>stable</tag>
@@ -24,10 +24,10 @@
 		<description>Joomla! CMS</description>
 		<element>joomla</element>
 		<type>file</type>
-		<version>6.0.0-alpha1-dev</version>
+		<version>6.0.0-alpha2-dev</version>
 		<infourl title="Joomla! Nightly Builds">https://developer.joomla.org/nightly-builds.html</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_6.0.0-alpha1-dev-Development-Update_Package.zip</downloadurl>
+			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_6.0.0-alpha2-dev-Development-Update_Package.zip</downloadurl>
 		</downloads>
 		<tags>
 			<tag>stable</tag>

--- a/www/core/nightlies/next_major_list.xml
+++ b/www/core/nightlies/next_major_list.xml
@@ -1,4 +1,4 @@
 <extensionset name="Joomla! Core Nightly Builds" description="Joomla! Core Next Major Nightly Builds">
-	<extension name="Joomla" element="joomla" type="file" version="6.0.0-alpha1-dev" targetplatformversion="5.4" detailsurl="https://update.joomla.org/core/nightlies/next_major_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="6.0.0-alpha1-dev" targetplatformversion="6.0" detailsurl="https://update.joomla.org/core/nightlies/next_major_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="6.0.0-alpha2-dev" targetplatformversion="5.4" detailsurl="https://update.joomla.org/core/nightlies/next_major_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="6.0.0-alpha2-dev" targetplatformversion="6.0" detailsurl="https://update.joomla.org/core/nightlies/next_major_extension.xml" />
 </extensionset>

--- a/www/core/nightlies/next_minor_extension.xml
+++ b/www/core/nightlies/next_minor_extension.xml
@@ -5,10 +5,10 @@
 		<description>Joomla! CMS</description>
 		<element>joomla</element>
 		<type>file</type>
-		<version>5.4.0-alpha1-dev</version>
+		<version>5.4.0-alpha2-dev</version>
 		<infourl title="Joomla! Nightly Builds">https://developer.joomla.org/nightly-builds.html</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_5.4.0-alpha1-dev-Development-Update_Package.zip</downloadurl>
+			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_5.4.0-alpha2-dev-Development-Update_Package.zip</downloadurl>
 		</downloads>
 		<tags>
 			<tag>stable</tag>
@@ -24,10 +24,10 @@
 		<description>Joomla! CMS</description>
 		<element>joomla</element>
 		<type>file</type>
-		<version>5.4.0-alpha1-dev</version>
+		<version>5.4.0-alpha2-dev</version>
 		<infourl title="Joomla! Nightly Builds">https://developer.joomla.org/nightly-builds.html</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_5.4.0-alpha1-dev-Development-Update_Package.zip</downloadurl>
+			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_5.4.0-alpha2-dev-Development-Update_Package.zip</downloadurl>
 		</downloads>
 		<tags>
 			<tag>stable</tag>

--- a/www/core/nightlies/next_minor_list.xml
+++ b/www/core/nightlies/next_minor_list.xml
@@ -1,9 +1,9 @@
 <extensionset name="Joomla! Core Nightly Builds" description="Joomla! Core Next Minor Nightly Builds">
-	<extension name="Joomla" element="joomla" type="file" version="5.4.0-alpha1-dev" targetplatformversion="4.4.13" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="5.4.0-alpha1-dev" targetplatformversion="4.4.14" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="5.4.0-alpha1-dev" targetplatformversion="5.0" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="5.4.0-alpha1-dev" targetplatformversion="5.1" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="5.4.0-alpha1-dev" targetplatformversion="5.2" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="5.4.0-alpha1-dev" targetplatformversion="5.3" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="5.4.0-alpha1-dev" targetplatformversion="5.4" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.4.0-alpha2-dev" targetplatformversion="4.4.13" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.4.0-alpha2-dev" targetplatformversion="4.4.14" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.4.0-alpha2-dev" targetplatformversion="5.0" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.4.0-alpha2-dev" targetplatformversion="5.1" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.4.0-alpha2-dev" targetplatformversion="5.2" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.4.0-alpha2-dev" targetplatformversion="5.3" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.4.0-alpha2-dev" targetplatformversion="5.4" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
 </extensionset>


### PR DESCRIPTION
This pull request (PR) changes the next minor nightly builds from `5.4.0-alpha1-dev` to `5.4.0-alpha2-dev` and the next major nightly builds from `6.0.0-alpha1-dev` to `6.0.0-alpha2-dev`.

It has to be merged after the 5.4.0 alpha1 and 6.0.0 alpha1 releases on Tuesday, May 27, 2025.