### PR TITLE
Update j4 and j5 XML stable update sites to 5.4.0 stable

### DIFF
--- a/www/core/j4/next.xml
+++ b/www/core/j4/next.xml
@@ -1,25 +1,25 @@
 <?xml version="1.0" ?>
 <updates>
 	<update>
-		<name>Joomla! 5.3</name>
-		<description>Joomla! 5.3 CMS</description>
+		<name>Joomla! 5.4</name>
+		<description>Joomla! 5.4 CMS</description>
 		<element>joomla</element>
 		<type>file</type>
-		<version>5.3.4</version>
-		<infourl title="Joomla 5.3.4 Release">https://www.joomla.org/announcements/release-news/5936-joomla-5-3-4-security-bugfix-release.html</infourl>
+		<version>5.4.0</version>
+		<infourl title="Joomla 5.4.0 Release">https://www.joomla.org/announcements/release-news/5939-joomla-6-0-and-joomla-5-4-are-here.html</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://downloads.joomla.org/cms/joomla5/5-3-4/Joomla_5.3.4-Stable-Update_Package.zip</downloadurl>
-			<downloadsource type="full" format="zip">https://github.com/joomla/joomla-cms/releases/download/5.3.4/Joomla_5.3.4-Stable-Update_Package.zip</downloadsource>
-			<downloadsource type="full" format="zip">https://update.joomla.org/releases/5.3.4/Joomla_5.3.4-Stable-Update_Package.zip</downloadsource>
+			<downloadurl type="full" format="zip">https://downloads.joomla.org/cms/joomla5/5-4-0/Joomla_5.4.0-Stable-Update_Package.zip</downloadurl>
+			<downloadsource type="full" format="zip">https://github.com/joomla/joomla-cms/releases/download/5.4.0/Joomla_5.4.0-Stable-Update_Package.zip</downloadsource>
+			<downloadsource type="full" format="zip">https://update.joomla.org/releases/5.4.0/Joomla_5.4.0-Stable-Update_Package.zip</downloadsource>
 		</downloads>
 		<tags>
 			<tag>stable</tag>
 		</tags>
 		<supported_databases mysql="8.0.13" mariadb="10.4" postgresql="12.0" />
 		<php_minimum>8.1.0</php_minimum>
-		<sha256>ec22816bd07df15c1c361d8350c6885bc2558d699c805b7ca79459a4be8203a9</sha256>
-		<sha384>08de732cd0d8701d29124b51aaad6c9e7f10122d8ff1a8ffe3d1066bfda0eb8473f97be96226658dc2722861376208e8</sha384>
-		<sha512>12a386645464b4f973ec28b40252cca28f56fdbe3f89efa37a4deaebb3334088c427e74bb90fa3068efc2df785a96510befde496f6341bd83f2a1b45b3d693ea</sha512>
+		<sha256>66eaef60b588764d762c290b16be7c625d677a3bed8a92ef628b2cdbaa2f32d7</sha256>
+		<sha384>065066e4b7d6a8529add7a0da0016b715c4864885745eabddb9b1f658e48e8b909ef2e939f50aa18756d1ac760290150</sha384>
+		<sha512>c862b2674acd3f7da6062ea2a0defa35c2c5c9091eaf742106f6cf5793d321ed7a9b99901c7ad15845cef4e4cb7e2806af64794fdcf5a30b7e1c4db60bcd10ae</sha512>
 		<maintainer>Joomla! Production Department</maintainer>
 		<maintainerurl>https://www.joomla.org</maintainerurl>
 		<section>STS</section>

--- a/www/core/j5/default.xml
+++ b/www/core/j5/default.xml
@@ -1,28 +1,28 @@
 <?xml version="1.0" ?>
 <updates>
 	<update>
-		<name>Joomla! 5.3</name>
-		<description>Joomla! 5.3 CMS</description>
+		<name>Joomla! 5.4</name>
+		<description>Joomla! 5.4 CMS</description>
 		<element>joomla</element>
 		<type>file</type>
-		<version>5.3.4</version>
-		<infourl title="Joomla 5.3.4 Release">https://www.joomla.org/announcements/release-news/5936-joomla-5-3-4-security-bugfix-release.html</infourl>
+		<version>5.4.0</version>
+		<infourl title="Joomla 5.4.0 Release">https://www.joomla.org/announcements/release-news/5939-joomla-6-0-and-joomla-5-4-are-here.html</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://downloads.joomla.org/cms/joomla5/5-3-4/Joomla_5.3.4-Stable-Update_Package.zip</downloadurl>
-			<downloadsource type="full" format="zip">https://github.com/joomla/joomla-cms/releases/download/5.3.4/Joomla_5.3.4-Stable-Update_Package.zip</downloadsource>
-			<downloadsource type="full" format="zip">https://update.joomla.org/releases/5.3.4/Joomla_5.3.4-Stable-Update_Package.zip</downloadsource>
+			<downloadurl type="full" format="zip">https://downloads.joomla.org/cms/joomla5/5-4-0/Joomla_5.4.0-Stable-Update_Package.zip</downloadurl>
+			<downloadsource type="full" format="zip">https://github.com/joomla/joomla-cms/releases/download/5.4.0/Joomla_5.4.0-Stable-Update_Package.zip</downloadsource>
+			<downloadsource type="full" format="zip">https://update.joomla.org/releases/5.4.0/Joomla_5.4.0-Stable-Update_Package.zip</downloadsource>
 		</downloads>
 		<tags>
 			<tag>stable</tag>
 		</tags>
 		<supported_databases mysql="8.0.13" mariadb="10.4" postgresql="12.0" />
 		<php_minimum>8.1.0</php_minimum>
-		<sha256>ec22816bd07df15c1c361d8350c6885bc2558d699c805b7ca79459a4be8203a9</sha256>
-		<sha384>08de732cd0d8701d29124b51aaad6c9e7f10122d8ff1a8ffe3d1066bfda0eb8473f97be96226658dc2722861376208e8</sha384>
-		<sha512>12a386645464b4f973ec28b40252cca28f56fdbe3f89efa37a4deaebb3334088c427e74bb90fa3068efc2df785a96510befde496f6341bd83f2a1b45b3d693ea</sha512>
+		<sha256>66eaef60b588764d762c290b16be7c625d677a3bed8a92ef628b2cdbaa2f32d7</sha256>
+		<sha384>065066e4b7d6a8529add7a0da0016b715c4864885745eabddb9b1f658e48e8b909ef2e939f50aa18756d1ac760290150</sha384>
+		<sha512>c862b2674acd3f7da6062ea2a0defa35c2c5c9091eaf742106f6cf5793d321ed7a9b99901c7ad15845cef4e4cb7e2806af64794fdcf5a30b7e1c4db60bcd10ae</sha512>
 		<maintainer>Joomla! Production Department</maintainer>
 		<maintainerurl>https://www.joomla.org</maintainerurl>
 		<section>STS</section>
-		<targetplatform name="joomla" version="5.[0123]" />
+		<targetplatform name="joomla" version="5.[01234]" />
 	</update>
 </updates>

--- a/www/core/j5/next.xml
+++ b/www/core/j5/next.xml
@@ -1,28 +1,28 @@
 <?xml version="1.0" ?>
 <updates>
 	<update>
-		<name>Joomla! 5.3</name>
-		<description>Joomla! 5.3 CMS</description>
+		<name>Joomla! 5.4</name>
+		<description>Joomla! 5.4 CMS</description>
 		<element>joomla</element>
 		<type>file</type>
-		<version>5.3.4</version>
-		<infourl title="Joomla 5.3.4 Release">https://www.joomla.org/announcements/release-news/5936-joomla-5-3-4-security-bugfix-release.html</infourl>
+		<version>5.4.0</version>
+		<infourl title="Joomla 5.4.0 Release">https://www.joomla.org/announcements/release-news/5939-joomla-6-0-and-joomla-5-4-are-here.html</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://downloads.joomla.org/cms/joomla5/5-3-4/Joomla_5.3.4-Stable-Update_Package.zip</downloadurl>
-			<downloadsource type="full" format="zip">https://github.com/joomla/joomla-cms/releases/download/5.3.4/Joomla_5.3.4-Stable-Update_Package.zip</downloadsource>
-			<downloadsource type="full" format="zip">https://update.joomla.org/releases/5.3.4/Joomla_5.3.4-Stable-Update_Package.zip</downloadsource>
+			<downloadurl type="full" format="zip">https://downloads.joomla.org/cms/joomla5/5-4-0/Joomla_5.4.0-Stable-Update_Package.zip</downloadurl>
+			<downloadsource type="full" format="zip">https://github.com/joomla/joomla-cms/releases/download/5.4.0/Joomla_5.4.0-Stable-Update_Package.zip</downloadsource>
+			<downloadsource type="full" format="zip">https://update.joomla.org/releases/5.4.0/Joomla_5.4.0-Stable-Update_Package.zip</downloadsource>
 		</downloads>
 		<tags>
 			<tag>stable</tag>
 		</tags>
 		<supported_databases mysql="8.0.13" mariadb="10.4" postgresql="12.0" />
 		<php_minimum>8.1.0</php_minimum>
-		<sha256>ec22816bd07df15c1c361d8350c6885bc2558d699c805b7ca79459a4be8203a9</sha256>
-		<sha384>08de732cd0d8701d29124b51aaad6c9e7f10122d8ff1a8ffe3d1066bfda0eb8473f97be96226658dc2722861376208e8</sha384>
-		<sha512>12a386645464b4f973ec28b40252cca28f56fdbe3f89efa37a4deaebb3334088c427e74bb90fa3068efc2df785a96510befde496f6341bd83f2a1b45b3d693ea</sha512>
+		<sha256>66eaef60b588764d762c290b16be7c625d677a3bed8a92ef628b2cdbaa2f32d7</sha256>
+		<sha384>065066e4b7d6a8529add7a0da0016b715c4864885745eabddb9b1f658e48e8b909ef2e939f50aa18756d1ac760290150</sha384>
+		<sha512>c862b2674acd3f7da6062ea2a0defa35c2c5c9091eaf742106f6cf5793d321ed7a9b99901c7ad15845cef4e4cb7e2806af64794fdcf5a30b7e1c4db60bcd10ae</sha512>
 		<maintainer>Joomla! Production Department</maintainer>
 		<maintainerurl>https://www.joomla.org</maintainerurl>
 		<section>STS</section>
-		<targetplatform name="joomla" version="5.[0123]" />
+		<targetplatform name="joomla" version="5.[01234]" />
 	</update>
 </updates>

--- a/www/core/list.xml
+++ b/www/core/list.xml
@@ -22,9 +22,10 @@
 	<extension name="Joomla" element="joomla" type="file" version="4.4.14" targetplatformversion="4.2" detailsurl="https://update.joomla.org/core/j4/default.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="4.4.14" targetplatformversion="4.3" detailsurl="https://update.joomla.org/core/j4/default.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="4.4.14" targetplatformversion="4.4" detailsurl="https://update.joomla.org/core/j4/default.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="5.3.4" targetplatformversion="5.0" detailsurl="https://update.joomla.org/core/j5/default.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="5.3.4" targetplatformversion="5.1" detailsurl="https://update.joomla.org/core/j5/default.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="5.3.4" targetplatformversion="5.2" detailsurl="https://update.joomla.org/core/j5/default.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="5.3.4" targetplatformversion="5.3" detailsurl="https://update.joomla.org/core/j5/default.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.4.0" targetplatformversion="5.0" detailsurl="https://update.joomla.org/core/j5/default.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.4.0" targetplatformversion="5.1" detailsurl="https://update.joomla.org/core/j5/default.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.4.0" targetplatformversion="5.2" detailsurl="https://update.joomla.org/core/j5/default.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.4.0" targetplatformversion="5.3" detailsurl="https://update.joomla.org/core/j5/default.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.4.0" targetplatformversion="5.4" detailsurl="https://update.joomla.org/core/j5/default.xml" />
 </extensionset>
 

--- a/www/core/sts/list_sts.xml
+++ b/www/core/sts/list_sts.xml
@@ -23,10 +23,11 @@
 	<extension name="Joomla" element="joomla" type="file" version="4.4.14" targetplatformversion="4.1" detailsurl="https://update.joomla.org/core/j4/default.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="4.4.14" targetplatformversion="4.2" detailsurl="https://update.joomla.org/core/j4/default.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="4.4.14" targetplatformversion="4.3" detailsurl="https://update.joomla.org/core/j4/default.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="5.3.4" targetplatformversion="4.4.14" detailsurl="https://update.joomla.org/core/j4/next.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.4.0" targetplatformversion="4.4.14" detailsurl="https://update.joomla.org/core/j4/next.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="4.4.14" targetplatformversion="4.4" detailsurl="https://update.joomla.org/core/j4/default.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="5.3.4" targetplatformversion="5.0" detailsurl="https://update.joomla.org/core/j5/next.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="5.3.4" targetplatformversion="5.1" detailsurl="https://update.joomla.org/core/j5/next.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="5.3.4" targetplatformversion="5.2" detailsurl="https://update.joomla.org/core/j5/next.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="5.3.4" targetplatformversion="5.3" detailsurl="https://update.joomla.org/core/j5/next.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.4.0" targetplatformversion="5.0" detailsurl="https://update.joomla.org/core/j5/next.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.4.0" targetplatformversion="5.1" detailsurl="https://update.joomla.org/core/j5/next.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.4.0" targetplatformversion="5.2" detailsurl="https://update.joomla.org/core/j5/next.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.4.0" targetplatformversion="5.3" detailsurl="https://update.joomla.org/core/j5/next.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.4.0" targetplatformversion="5.4" detailsurl="https://update.joomla.org/core/j5/next.xml" />
 </extensionset>


### PR DESCRIPTION
This pull request (PR) has to be merged immediately after the release of 5.4.0 stable on October 14.

It updates the XML update sites for 4.4 and early 5.x installations, which did not use TUF yet, to the new 5.4.0 release.

The logic is kept as it is, so `www/core/list.xml` does not provide an update path to a new major version, while `www/core/sts/list_sts.xml` does.

This PR does not add anything to these XML files or any new XML files for updating to Joomla 6 because such an update can only be done from the latest 5.4 version, and that uses TUF in any case.

It also does not handle the nightly builds, that will be done with a separate PR.

PRs like this here have to be made during the life time of Joomla 5.

As soon as Joomla 5.4 has reached end of life it will not need that anymore, only the nightly build update sites still need to be maintained after that.