### PR TITLE
Update nightly build update sites after 5.4.6, 6.1.1 and 6.2.0-alpha1 releases on May 26, 2026

### DIFF
--- a/www/core/nightlies/next_minor_extension.xml
+++ b/www/core/nightlies/next_minor_extension.xml
@@ -5,10 +5,10 @@
 		<description>Joomla! CMS</description>
 		<element>joomla</element>
 		<type>file</type>
-		<version>6.2.0-alpha1-dev</version>
+		<version>6.2.0-alpha2-dev</version>
 		<infourl title="Joomla! Nightly Builds">https://developer.joomla.org/nightly-builds.html</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_6.2.0-alpha1-dev-Development-Update_Package.zip</downloadurl>
+			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_6.2.0-alpha2-dev-Development-Update_Package.zip</downloadurl>
 		</downloads>
 		<tags>
 			<tag>stable</tag>
@@ -17,17 +17,17 @@
 		<php_minimum>8.3.0</php_minimum>
 		<maintainer>Joomla! Production Department</maintainer>
 		<maintainerurl>https://www.joomla.org</maintainerurl>
-		<targetplatform name="joomla" version="5.4.[56]" />
+		<targetplatform name="joomla" version="5.4.[67]" />
 	</update>
 	<update>
 		<name>Joomla! 6.2 Nightly Build</name>
 		<description>Joomla! CMS</description>
 		<element>joomla</element>
 		<type>file</type>
-		<version>6.2.0-alpha1-dev</version>
+		<version>6.2.0-alpha2-dev</version>
 		<infourl title="Joomla! Nightly Builds">https://developer.joomla.org/nightly-builds.html</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_6.2.0-alpha1-dev-Development-Update_Package.zip</downloadurl>
+			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_6.2.0-alpha2-dev-Development-Update_Package.zip</downloadurl>
 		</downloads>
 		<tags>
 			<tag>stable</tag>
@@ -36,6 +36,6 @@
 		<php_minimum>8.3.0</php_minimum>
 		<maintainer>Joomla! Production Department</maintainer>
 		<maintainerurl>https://www.joomla.org</maintainerurl>
-		<targetplatform name="joomla" version="6.[12]" />
+		<targetplatform name="joomla" version="6.[012]" />
 	</update>
 </updates>

--- a/www/core/nightlies/next_minor_list.xml
+++ b/www/core/nightlies/next_minor_list.xml
@@ -1,6 +1,7 @@
 <extensionset name="Joomla! Core Nightly Builds" description="Joomla! Core Next Minor Nightly Builds">
-	<extension name="Joomla" element="joomla" type="file" version="6.2.0-alpha1-dev" targetplatformversion="5.4.5" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="6.2.0-alpha1-dev" targetplatformversion="5.4.6" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="6.2.0-alpha1-dev" targetplatformversion="6.1" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="6.2.0-alpha1-dev" targetplatformversion="6.2" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="6.2.0-alpha2-dev" targetplatformversion="5.4.6" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="6.2.0-alpha2-dev" targetplatformversion="5.4.7" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="6.2.0-alpha2-dev" targetplatformversion="6.0" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="6.2.0-alpha2-dev" targetplatformversion="6.1" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="6.2.0-alpha2-dev" targetplatformversion="6.2" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
 </extensionset>

--- a/www/core/nightlies/next_patch_extension.xml
+++ b/www/core/nightlies/next_patch_extension.xml
@@ -5,10 +5,10 @@
 		<description>Joomla! CMS</description>
 		<element>joomla</element>
 		<type>file</type>
-		<version>5.4.6-rc2-dev</version>
+		<version>5.4.7-dev</version>
 		<infourl title="Joomla! Nightly Builds">https://developer.joomla.org/nightly-builds.html</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_5.4.6-rc2-dev-Development-Update_Package.zip</downloadurl>
+			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_5.4.7-dev-Development-Update_Package.zip</downloadurl>
 		</downloads>
 		<tags>
 			<tag>stable</tag>
@@ -24,10 +24,10 @@
 		<description>Joomla! CMS</description>
 		<element>joomla</element>
 		<type>file</type>
-		<version>5.4.6-rc2-dev</version>
+		<version>5.4.7-dev</version>
 		<infourl title="Joomla! Nightly Builds">https://developer.joomla.org/nightly-builds.html</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_5.4.6-rc2-dev-Development-Update_Package.zip</downloadurl>
+			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_5.4.7-dev-Development-Update_Package.zip</downloadurl>
 		</downloads>
 		<tags>
 			<tag>stable</tag>
@@ -43,10 +43,10 @@
 		<description>Joomla! CMS</description>
 		<element>joomla</element>
 		<type>file</type>
-		<version>6.1.1-rc2-dev</version>
+		<version>6.1.2-dev</version>
 		<infourl title="Joomla! Nightly Builds">https://developer.joomla.org/nightly-builds.html</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_6.1.1-rc2-dev-Development-Update_Package.zip</downloadurl>
+			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_6.1.2-dev-Development-Update_Package.zip</downloadurl>
 		</downloads>
 		<tags>
 			<tag>stable</tag>
@@ -55,17 +55,17 @@
 		<php_minimum>8.3.0</php_minimum>
 		<maintainer>Joomla! Production Department</maintainer>
 		<maintainerurl>https://www.joomla.org</maintainerurl>
-		<targetplatform name="joomla" version="5.4.[56]" />
+		<targetplatform name="joomla" version="5.4.[67]" />
 	</update>
 	<update>
 		<name>Joomla! 6.1 Nightly Build</name>
 		<description>Joomla! CMS</description>
 		<element>joomla</element>
 		<type>file</type>
-		<version>6.1.1-rc2-dev</version>
+		<version>6.1.2-dev</version>
 		<infourl title="Joomla! Nightly Builds">https://developer.joomla.org/nightly-builds.html</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_6.1.1-rc2-dev-Development-Update_Package.zip</downloadurl>
+			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_6.1.2-dev-Development-Update_Package.zip</downloadurl>
 		</downloads>
 		<tags>
 			<tag>stable</tag>

--- a/www/core/nightlies/next_patch_list.xml
+++ b/www/core/nightlies/next_patch_list.xml
@@ -1,13 +1,13 @@
 <extensionset name="Joomla! Core Nightly Builds" description="Joomla! Core Next Patch Nightly Builds">
-	<extension name="Joomla" element="joomla" type="file" version="5.4.6-rc2-dev" targetplatformversion="4.4.14" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="5.4.6-rc2-dev" targetplatformversion="4.4.15" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="5.4.6-rc2-dev" targetplatformversion="5.0" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="5.4.6-rc2-dev" targetplatformversion="5.1" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="5.4.6-rc2-dev" targetplatformversion="5.2" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="5.4.6-rc2-dev" targetplatformversion="5.3" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="6.1.1-rc2-dev" targetplatformversion="5.4.5" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="6.1.1-rc2-dev" targetplatformversion="5.4.6" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="5.4.6-rc2-dev" targetplatformversion="5.4" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="6.1.1-rc2-dev" targetplatformversion="6.0" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="6.1.1-rc2-dev" targetplatformversion="6.1" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.4.7-dev" targetplatformversion="4.4.14" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.4.7-dev" targetplatformversion="4.4.15" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.4.7-dev" targetplatformversion="5.0" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.4.7-dev" targetplatformversion="5.1" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.4.7-dev" targetplatformversion="5.2" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.4.7-dev" targetplatformversion="5.3" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="6.1.2-dev" targetplatformversion="5.4.6" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="6.1.2-dev" targetplatformversion="5.4.7" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.4.7-dev" targetplatformversion="5.4" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="6.1.2-dev" targetplatformversion="6.0" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="6.1.2-dev" targetplatformversion="6.1" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
 </extensionset>


### PR DESCRIPTION
This pull request (PR) has to be merged after the 5.4.6 and 6.1.1 stable releases and the 6.2.0-alpha1 release on Tuesday, May 26, 2026.

In detail following is changed:
- **Next patch** nightly builds are changed from `5.4.6-rc2-dev` to `5.4.7-dev` for 5.4 and from `6.1.1-rc2-dev` to `6.1.2-dev` for 6.1.
The targetplatform requirement for going from 5.4 to 6.1 is changed from `5.4.[56]` to `5.4.[67]`.
- **Next minor** nightly builds are changed from `6.2.0-alpha1-dev` to `6.2.0-alpha2-dev`.
The targetplatform requirement for going from 5.4 to 6.2 is changed from `5.4.[56]` to `5.4.[67]`.
- For the **next minor** nightly builds, the targetplatform requirement for going from 6.x to 6.2 is changed from `6.[12]` to `6.[012]`.
It shall be possible to go to 6.2 from any previous 6.x version.
The `0` has been removed by mistake with one of my previous PRs, this PR here adds it back.

This PR is ready, but I will leave it in draft status until Tuesday, May 26, 2026.