### PR TITLE
Update nightlies after 5.4.7-rc1 and 6.1.2-rc1 releases on June 27, 2026

### DIFF
--- a/www/core/nightlies/next_patch_extension.xml
+++ b/www/core/nightlies/next_patch_extension.xml
@@ -43,10 +43,10 @@
 		<description>Joomla! CMS</description>
 		<element>joomla</element>
 		<type>file</type>
-		<version>6.1.2-dev</version>
+		<version>6.1.2-rc2-dev</version>
 		<infourl title="Joomla! Nightly Builds">https://developer.joomla.org/nightly-builds.html</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_6.1.2-dev-Development-Update_Package.zip</downloadurl>
+			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_6.1.2-rc2-dev-Development-Update_Package.zip</downloadurl>
 		</downloads>
 		<tags>
 			<tag>stable</tag>
@@ -62,10 +62,10 @@
 		<description>Joomla! CMS</description>
 		<element>joomla</element>
 		<type>file</type>
-		<version>6.1.2-dev</version>
+		<version>6.1.2-rc2-dev</version>
 		<infourl title="Joomla! Nightly Builds">https://developer.joomla.org/nightly-builds.html</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_6.1.2-dev-Development-Update_Package.zip</downloadurl>
+			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_6.1.2-rc2-dev-Development-Update_Package.zip</downloadurl>
 		</downloads>
 		<tags>
 			<tag>stable</tag>

--- a/www/core/nightlies/next_patch_extension.xml
+++ b/www/core/nightlies/next_patch_extension.xml
@@ -5,10 +5,10 @@
 		<description>Joomla! CMS</description>
 		<element>joomla</element>
 		<type>file</type>
-		<version>5.4.7-dev</version>
+		<version>5.4.7-rc2-dev</version>
 		<infourl title="Joomla! Nightly Builds">https://developer.joomla.org/nightly-builds.html</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_5.4.7-dev-Development-Update_Package.zip</downloadurl>
+			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_5.4.7-rc2-dev-Development-Update_Package.zip</downloadurl>
 		</downloads>
 		<tags>
 			<tag>stable</tag>
@@ -24,10 +24,10 @@
 		<description>Joomla! CMS</description>
 		<element>joomla</element>
 		<type>file</type>
-		<version>5.4.7-dev</version>
+		<version>5.4.7-rc2-dev</version>
 		<infourl title="Joomla! Nightly Builds">https://developer.joomla.org/nightly-builds.html</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_5.4.7-dev-Development-Update_Package.zip</downloadurl>
+			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_5.4.7-rc2-dev-Development-Update_Package.zip</downloadurl>
 		</downloads>
 		<tags>
 			<tag>stable</tag>

--- a/www/core/nightlies/next_patch_list.xml
+++ b/www/core/nightlies/next_patch_list.xml
@@ -5,9 +5,9 @@
 	<extension name="Joomla" element="joomla" type="file" version="5.4.7-rc2-dev" targetplatformversion="5.1" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="5.4.7-rc2-dev" targetplatformversion="5.2" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="5.4.7-rc2-dev" targetplatformversion="5.3" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="6.1.2-dev" targetplatformversion="5.4.6" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="6.1.2-dev" targetplatformversion="5.4.7" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="6.1.2-rc2-dev" targetplatformversion="5.4.6" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="6.1.2-rc2-dev" targetplatformversion="5.4.7" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="5.4.7-rc2-dev" targetplatformversion="5.4" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="6.1.2-dev" targetplatformversion="6.0" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="6.1.2-dev" targetplatformversion="6.1" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="6.1.2-rc2-dev" targetplatformversion="6.0" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="6.1.2-rc2-dev" targetplatformversion="6.1" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
 </extensionset>

--- a/www/core/nightlies/next_patch_list.xml
+++ b/www/core/nightlies/next_patch_list.xml
@@ -1,13 +1,13 @@
 <extensionset name="Joomla! Core Nightly Builds" description="Joomla! Core Next Patch Nightly Builds">
-	<extension name="Joomla" element="joomla" type="file" version="5.4.7-dev" targetplatformversion="4.4.14" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="5.4.7-dev" targetplatformversion="4.4.15" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="5.4.7-dev" targetplatformversion="5.0" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="5.4.7-dev" targetplatformversion="5.1" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="5.4.7-dev" targetplatformversion="5.2" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="5.4.7-dev" targetplatformversion="5.3" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.4.7-rc2-dev" targetplatformversion="4.4.14" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.4.7-rc2-dev" targetplatformversion="4.4.15" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.4.7-rc2-dev" targetplatformversion="5.0" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.4.7-rc2-dev" targetplatformversion="5.1" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.4.7-rc2-dev" targetplatformversion="5.2" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.4.7-rc2-dev" targetplatformversion="5.3" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="6.1.2-dev" targetplatformversion="5.4.6" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="6.1.2-dev" targetplatformversion="5.4.7" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="5.4.7-dev" targetplatformversion="5.4" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.4.7-rc2-dev" targetplatformversion="5.4" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="6.1.2-dev" targetplatformversion="6.0" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="6.1.2-dev" targetplatformversion="6.1" detailsurl="https://update.joomla.org/core/nightlies/next_patch_extension.xml" />
 </extensionset>


### PR DESCRIPTION
This pull request (PR) changes the next patch nightly builds from `5.4.7-dev` to `5.4.7-rc2-dev` for 5.4 and from `6.1.2-dev` to `6.1.2-rc2-dev` for 6.1.

It has to be merged after the 5.4.7-rc1 and 6.1.2-rc1 releases on Saturday, June 27, 2026.