### PR TITLE
Update j4 and j5 XML stable update sites after 5.4.7 stable release on July 7, 2026

### DIFF
--- a/www/core/j4/next.xml
+++ b/www/core/j4/next.xml
@@ -5,21 +5,21 @@
 		<description>Joomla! 5.4 CMS</description>
 		<element>joomla</element>
 		<type>file</type>
-		<version>5.4.6</version>
-		<infourl title="Joomla 5.4.6 Release">https://www.joomla.org/announcements/release-news/5954-joomla-6-1-1-5-4-6-security-bugfix-release.html</infourl>
+		<version>5.4.7</version>
+		<infourl title="Joomla 5.4.7 Release">https://www.joomla.org/announcements/release-news/5955-joomla-6-1-2-5-4-7-security-bugfix-release.html</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://downloads.joomla.org/cms/joomla5/5-4-6/Joomla_5.4.6-Stable-Update_Package.zip</downloadurl>
-			<downloadsource type="full" format="zip">https://github.com/joomla/joomla-cms/releases/download/5.4.6/Joomla_5.4.6-Stable-Update_Package.zip</downloadsource>
-			<downloadsource type="full" format="zip">https://update.joomla.org/releases/5.4.6/Joomla_5.4.6-Stable-Update_Package.zip</downloadsource>
+			<downloadurl type="full" format="zip">https://downloads.joomla.org/cms/joomla5/5-4-7/Joomla_5.4.7-Stable-Update_Package.zip</downloadurl>
+			<downloadsource type="full" format="zip">https://github.com/joomla/joomla-cms/releases/download/5.4.7/Joomla_5.4.7-Stable-Update_Package.zip</downloadsource>
+			<downloadsource type="full" format="zip">https://update.joomla.org/releases/5.4.7/Joomla_5.4.7-Stable-Update_Package.zip</downloadsource>
 		</downloads>
 		<tags>
 			<tag>stable</tag>
 		</tags>
 		<supported_databases mysql="8.0.13" mariadb="10.4" postgresql="12.0" />
 		<php_minimum>8.1.0</php_minimum>
-		<sha256>b477078fd86598275af286e3db0a368159f2856a000d5973de6bf47e1df718ea</sha256>
-		<sha384>6cbff880333c76d95cf43db2c282a03fa2bfa6a17ecea23d7049327aa6fadb412770aa2672c44900c8d06c1e9d1fa652</sha384>
-		<sha512>40d8b14c59c9af7ad098247a70d195c307f31597365cc4b5133b7ffc896c236b3266b45fc6c05879624c96e7f1af26b66ef3c371482b54b130b9faa65622f2fd</sha512>
+		<sha256>b2bea5d4a404cf0d48de7b5fa7e9cf7738b8a9af4ae520b8d71685e34bb0ebe0</sha256>
+		<sha384>48b82e68453952bd3f573539e43f94da97fc8554a62c347e0b25a6116606b388c06df24ba8ef461bad413ab8accfea23</sha384>
+		<sha512>e1abbac01fe804d4eb64b1327ace9db4356e39a8782ab547b5257be308ea9215badec27821eae936b9a2db2f120fc175357f54ac3ca5af2313ec2af52eb44223</sha512>
 		<maintainer>Joomla! Production Department</maintainer>
 		<maintainerurl>https://www.joomla.org</maintainerurl>
 		<section>STS</section>

--- a/www/core/j5/default.xml
+++ b/www/core/j5/default.xml
@@ -5,21 +5,21 @@
 		<description>Joomla! 5.4 CMS</description>
 		<element>joomla</element>
 		<type>file</type>
-		<version>5.4.6</version>
-		<infourl title="Joomla 5.4.6 Release">https://www.joomla.org/announcements/release-news/5954-joomla-6-1-1-5-4-6-security-bugfix-release.html</infourl>
+		<version>5.4.7</version>
+		<infourl title="Joomla 5.4.7 Release">https://www.joomla.org/announcements/release-news/5955-joomla-6-1-2-5-4-7-security-bugfix-release.html</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://downloads.joomla.org/cms/joomla5/5-4-6/Joomla_5.4.6-Stable-Update_Package.zip</downloadurl>
-			<downloadsource type="full" format="zip">https://github.com/joomla/joomla-cms/releases/download/5.4.6/Joomla_5.4.6-Stable-Update_Package.zip</downloadsource>
-			<downloadsource type="full" format="zip">https://update.joomla.org/releases/5.4.6/Joomla_5.4.6-Stable-Update_Package.zip</downloadsource>
+			<downloadurl type="full" format="zip">https://downloads.joomla.org/cms/joomla5/5-4-7/Joomla_5.4.7-Stable-Update_Package.zip</downloadurl>
+			<downloadsource type="full" format="zip">https://github.com/joomla/joomla-cms/releases/download/5.4.7/Joomla_5.4.7-Stable-Update_Package.zip</downloadsource>
+			<downloadsource type="full" format="zip">https://update.joomla.org/releases/5.4.7/Joomla_5.4.7-Stable-Update_Package.zip</downloadsource>
 		</downloads>
 		<tags>
 			<tag>stable</tag>
 		</tags>
 		<supported_databases mysql="8.0.13" mariadb="10.4" postgresql="12.0" />
 		<php_minimum>8.1.0</php_minimum>
-		<sha256>b477078fd86598275af286e3db0a368159f2856a000d5973de6bf47e1df718ea</sha256>
-		<sha384>6cbff880333c76d95cf43db2c282a03fa2bfa6a17ecea23d7049327aa6fadb412770aa2672c44900c8d06c1e9d1fa652</sha384>
-		<sha512>40d8b14c59c9af7ad098247a70d195c307f31597365cc4b5133b7ffc896c236b3266b45fc6c05879624c96e7f1af26b66ef3c371482b54b130b9faa65622f2fd</sha512>
+		<sha256>b2bea5d4a404cf0d48de7b5fa7e9cf7738b8a9af4ae520b8d71685e34bb0ebe0</sha256>
+		<sha384>48b82e68453952bd3f573539e43f94da97fc8554a62c347e0b25a6116606b388c06df24ba8ef461bad413ab8accfea23</sha384>
+		<sha512>e1abbac01fe804d4eb64b1327ace9db4356e39a8782ab547b5257be308ea9215badec27821eae936b9a2db2f120fc175357f54ac3ca5af2313ec2af52eb44223</sha512>
 		<maintainer>Joomla! Production Department</maintainer>
 		<maintainerurl>https://www.joomla.org</maintainerurl>
 		<section>STS</section>

--- a/www/core/j5/next.xml
+++ b/www/core/j5/next.xml
@@ -5,21 +5,21 @@
 		<description>Joomla! 5.4 CMS</description>
 		<element>joomla</element>
 		<type>file</type>
-		<version>5.4.6</version>
-		<infourl title="Joomla 5.4.6 Release">https://www.joomla.org/announcements/release-news/5954-joomla-6-1-1-5-4-6-security-bugfix-release.html</infourl>
+		<version>5.4.7</version>
+		<infourl title="Joomla 5.4.7 Release">https://www.joomla.org/announcements/release-news/5955-joomla-6-1-2-5-4-7-security-bugfix-release.html</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://downloads.joomla.org/cms/joomla5/5-4-6/Joomla_5.4.6-Stable-Update_Package.zip</downloadurl>
-			<downloadsource type="full" format="zip">https://github.com/joomla/joomla-cms/releases/download/5.4.6/Joomla_5.4.6-Stable-Update_Package.zip</downloadsource>
-			<downloadsource type="full" format="zip">https://update.joomla.org/releases/5.4.6/Joomla_5.4.6-Stable-Update_Package.zip</downloadsource>
+			<downloadurl type="full" format="zip">https://downloads.joomla.org/cms/joomla5/5-4-7/Joomla_5.4.7-Stable-Update_Package.zip</downloadurl>
+			<downloadsource type="full" format="zip">https://github.com/joomla/joomla-cms/releases/download/5.4.7/Joomla_5.4.7-Stable-Update_Package.zip</downloadsource>
+			<downloadsource type="full" format="zip">https://update.joomla.org/releases/5.4.7/Joomla_5.4.7-Stable-Update_Package.zip</downloadsource>
 		</downloads>
 		<tags>
 			<tag>stable</tag>
 		</tags>
 		<supported_databases mysql="8.0.13" mariadb="10.4" postgresql="12.0" />
 		<php_minimum>8.1.0</php_minimum>
-		<sha256>b477078fd86598275af286e3db0a368159f2856a000d5973de6bf47e1df718ea</sha256>
-		<sha384>6cbff880333c76d95cf43db2c282a03fa2bfa6a17ecea23d7049327aa6fadb412770aa2672c44900c8d06c1e9d1fa652</sha384>
-		<sha512>40d8b14c59c9af7ad098247a70d195c307f31597365cc4b5133b7ffc896c236b3266b45fc6c05879624c96e7f1af26b66ef3c371482b54b130b9faa65622f2fd</sha512>
+		<sha256>b2bea5d4a404cf0d48de7b5fa7e9cf7738b8a9af4ae520b8d71685e34bb0ebe0</sha256>
+		<sha384>48b82e68453952bd3f573539e43f94da97fc8554a62c347e0b25a6116606b388c06df24ba8ef461bad413ab8accfea23</sha384>
+		<sha512>e1abbac01fe804d4eb64b1327ace9db4356e39a8782ab547b5257be308ea9215badec27821eae936b9a2db2f120fc175357f54ac3ca5af2313ec2af52eb44223</sha512>
 		<maintainer>Joomla! Production Department</maintainer>
 		<maintainerurl>https://www.joomla.org</maintainerurl>
 		<section>STS</section>

--- a/www/core/list.xml
+++ b/www/core/list.xml
@@ -22,10 +22,10 @@
 	<extension name="Joomla" element="joomla" type="file" version="4.4.14" targetplatformversion="4.2" detailsurl="https://update.joomla.org/core/j4/default.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="4.4.14" targetplatformversion="4.3" detailsurl="https://update.joomla.org/core/j4/default.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="4.4.14" targetplatformversion="4.4" detailsurl="https://update.joomla.org/core/j4/default.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="5.4.6" targetplatformversion="5.0" detailsurl="https://update.joomla.org/core/j5/default.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="5.4.6" targetplatformversion="5.1" detailsurl="https://update.joomla.org/core/j5/default.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="5.4.6" targetplatformversion="5.2" detailsurl="https://update.joomla.org/core/j5/default.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="5.4.6" targetplatformversion="5.3" detailsurl="https://update.joomla.org/core/j5/default.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="5.4.6" targetplatformversion="5.4" detailsurl="https://update.joomla.org/core/j5/default.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.4.7" targetplatformversion="5.0" detailsurl="https://update.joomla.org/core/j5/default.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.4.7" targetplatformversion="5.1" detailsurl="https://update.joomla.org/core/j5/default.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.4.7" targetplatformversion="5.2" detailsurl="https://update.joomla.org/core/j5/default.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.4.7" targetplatformversion="5.3" detailsurl="https://update.joomla.org/core/j5/default.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.4.7" targetplatformversion="5.4" detailsurl="https://update.joomla.org/core/j5/default.xml" />
 </extensionset>
 

--- a/www/core/sts/list_sts.xml
+++ b/www/core/sts/list_sts.xml
@@ -23,11 +23,11 @@
 	<extension name="Joomla" element="joomla" type="file" version="4.4.14" targetplatformversion="4.1" detailsurl="https://update.joomla.org/core/j4/default.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="4.4.14" targetplatformversion="4.2" detailsurl="https://update.joomla.org/core/j4/default.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="4.4.14" targetplatformversion="4.3" detailsurl="https://update.joomla.org/core/j4/default.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="5.4.6" targetplatformversion="4.4.14" detailsurl="https://update.joomla.org/core/j4/next.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.4.7" targetplatformversion="4.4.14" detailsurl="https://update.joomla.org/core/j4/next.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="4.4.14" targetplatformversion="4.4" detailsurl="https://update.joomla.org/core/j4/default.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="5.4.6" targetplatformversion="5.0" detailsurl="https://update.joomla.org/core/j5/next.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="5.4.6" targetplatformversion="5.1" detailsurl="https://update.joomla.org/core/j5/next.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="5.4.6" targetplatformversion="5.2" detailsurl="https://update.joomla.org/core/j5/next.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="5.4.6" targetplatformversion="5.3" detailsurl="https://update.joomla.org/core/j5/next.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="5.4.6" targetplatformversion="5.4" detailsurl="https://update.joomla.org/core/j5/next.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.4.7" targetplatformversion="5.0" detailsurl="https://update.joomla.org/core/j5/next.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.4.7" targetplatformversion="5.1" detailsurl="https://update.joomla.org/core/j5/next.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.4.7" targetplatformversion="5.2" detailsurl="https://update.joomla.org/core/j5/next.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.4.7" targetplatformversion="5.3" detailsurl="https://update.joomla.org/core/j5/next.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.4.7" targetplatformversion="5.4" detailsurl="https://update.joomla.org/core/j5/next.xml" />
 </extensionset>


### PR DESCRIPTION
This pull request (PR) has to be merged after the 5.4.7 stable release on Tuesday, July 7, 2026.

It updates the j4 and j5 XML stable update sites to point to that release.

The updates for the nightly build update sites for 5.4.7 and 6.1.2 are made with PR #456 .