### PR TITLE
Update j4 and j5 XML stable update sites after 5.4.8 stable release on August 18, 2026

### DIFF
--- a/www/core/j4/next.xml
+++ b/www/core/j4/next.xml
@@ -17,9 +17,9 @@
 		</tags>
 		<supported_databases mysql="8.0.13" mariadb="10.4" postgresql="12.0" />
 		<php_minimum>8.1.0</php_minimum>
-		<sha256>f6cc93bd182d2f7fa0b6f5994286a0c2aa7cd81d00dfedf8b04ff63fc6af4b5c</sha256>
-		<sha384>1fd28b9a17551827b16ea0da103a3fb1e0c1ec24e6285074520dffb7ce63f76c21b8a42c724f6c5a35e1e602049d083f</sha384>
-		<sha512>d11181d2beb2a407318f746024dabf4696931a9a094d3540d9fb0a24983b9bd1aca6f50053382d1a15e29f28f555fd7e7ce931c1e03cf429378beb1b552992a6</sha512>
+		<sha256>2c1c4742a9ba5cffb2671e59b6320c26158737a24e169659f706239fadfd2d86</sha256>
+		<sha384>488a6a3fd93d0c6c219dc93b064f2626b201f626c4692062b6b88cc8a19fe7513de595c666eb2618e5e3aaff4107f976</sha384>
+		<sha512>86e9451f94887dbbee1475596fb91d58c2650e12cebfa976d2e0962e94e71d93683b42ce2d911cc9911ea42ca28e9c341dd002ddd8814f41a372e1732a5d0b3e</sha512>
 		<maintainer>Joomla! Production Department</maintainer>
 		<maintainerurl>https://www.joomla.org</maintainerurl>
 		<section>STS</section>

--- a/www/core/j4/next.xml
+++ b/www/core/j4/next.xml
@@ -5,21 +5,21 @@
 		<description>Joomla! 5.4 CMS</description>
 		<element>joomla</element>
 		<type>file</type>
-		<version>5.4.7</version>
-		<infourl title="Joomla 5.4.7 Release">https://www.joomla.org/announcements/release-news/5955-joomla-6-1-2-5-4-7-security-bugfix-release.html</infourl>
+		<version>5.4.8</version>
+		<infourl title="Joomla 5.4.8 Release">https://www.joomla.org/announcements/release-news/5957-joomla-6-1-3-5-4-8-security-bugfix-release.html</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://downloads.joomla.org/cms/joomla5/5-4-7/Joomla_5.4.7-Stable-Update_Package.zip</downloadurl>
-			<downloadsource type="full" format="zip">https://github.com/joomla/joomla-cms/releases/download/5.4.7/Joomla_5.4.7-Stable-Update_Package.zip</downloadsource>
-			<downloadsource type="full" format="zip">https://update.joomla.org/releases/5.4.7/Joomla_5.4.7-Stable-Update_Package.zip</downloadsource>
+			<downloadurl type="full" format="zip">https://downloads.joomla.org/cms/joomla5/5-4-8/Joomla_5.4.8-Stable-Update_Package.zip</downloadurl>
+			<downloadsource type="full" format="zip">https://github.com/joomla/joomla-cms/releases/download/5.4.8/Joomla_5.4.8-Stable-Update_Package.zip</downloadsource>
+			<downloadsource type="full" format="zip">https://update.joomla.org/releases/5.4.8/Joomla_5.4.8-Stable-Update_Package.zip</downloadsource>
 		</downloads>
 		<tags>
 			<tag>stable</tag>
 		</tags>
 		<supported_databases mysql="8.0.13" mariadb="10.4" postgresql="12.0" />
 		<php_minimum>8.1.0</php_minimum>
-		<sha256>b2bea5d4a404cf0d48de7b5fa7e9cf7738b8a9af4ae520b8d71685e34bb0ebe0</sha256>
-		<sha384>48b82e68453952bd3f573539e43f94da97fc8554a62c347e0b25a6116606b388c06df24ba8ef461bad413ab8accfea23</sha384>
-		<sha512>e1abbac01fe804d4eb64b1327ace9db4356e39a8782ab547b5257be308ea9215badec27821eae936b9a2db2f120fc175357f54ac3ca5af2313ec2af52eb44223</sha512>
+		<sha256>f6cc93bd182d2f7fa0b6f5994286a0c2aa7cd81d00dfedf8b04ff63fc6af4b5c</sha256>
+		<sha384>1fd28b9a17551827b16ea0da103a3fb1e0c1ec24e6285074520dffb7ce63f76c21b8a42c724f6c5a35e1e602049d083f</sha384>
+		<sha512>d11181d2beb2a407318f746024dabf4696931a9a094d3540d9fb0a24983b9bd1aca6f50053382d1a15e29f28f555fd7e7ce931c1e03cf429378beb1b552992a6</sha512>
 		<maintainer>Joomla! Production Department</maintainer>
 		<maintainerurl>https://www.joomla.org</maintainerurl>
 		<section>STS</section>

--- a/www/core/j5/default.xml
+++ b/www/core/j5/default.xml
@@ -17,9 +17,9 @@
 		</tags>
 		<supported_databases mysql="8.0.13" mariadb="10.4" postgresql="12.0" />
 		<php_minimum>8.1.0</php_minimum>
-		<sha256>f6cc93bd182d2f7fa0b6f5994286a0c2aa7cd81d00dfedf8b04ff63fc6af4b5c</sha256>
-		<sha384>1fd28b9a17551827b16ea0da103a3fb1e0c1ec24e6285074520dffb7ce63f76c21b8a42c724f6c5a35e1e602049d083f</sha384>
-		<sha512>d11181d2beb2a407318f746024dabf4696931a9a094d3540d9fb0a24983b9bd1aca6f50053382d1a15e29f28f555fd7e7ce931c1e03cf429378beb1b552992a6</sha512>
+		<sha256>2c1c4742a9ba5cffb2671e59b6320c26158737a24e169659f706239fadfd2d86</sha256>
+		<sha384>488a6a3fd93d0c6c219dc93b064f2626b201f626c4692062b6b88cc8a19fe7513de595c666eb2618e5e3aaff4107f976</sha384>
+		<sha512>86e9451f94887dbbee1475596fb91d58c2650e12cebfa976d2e0962e94e71d93683b42ce2d911cc9911ea42ca28e9c341dd002ddd8814f41a372e1732a5d0b3e</sha512>
 		<maintainer>Joomla! Production Department</maintainer>
 		<maintainerurl>https://www.joomla.org</maintainerurl>
 		<section>STS</section>

--- a/www/core/j5/default.xml
+++ b/www/core/j5/default.xml
@@ -5,21 +5,21 @@
 		<description>Joomla! 5.4 CMS</description>
 		<element>joomla</element>
 		<type>file</type>
-		<version>5.4.7</version>
-		<infourl title="Joomla 5.4.7 Release">https://www.joomla.org/announcements/release-news/5955-joomla-6-1-2-5-4-7-security-bugfix-release.html</infourl>
+		<version>5.4.8</version>
+		<infourl title="Joomla 5.4.8 Release">https://www.joomla.org/announcements/release-news/5957-joomla-6-1-3-5-4-8-security-bugfix-release.html</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://downloads.joomla.org/cms/joomla5/5-4-7/Joomla_5.4.7-Stable-Update_Package.zip</downloadurl>
-			<downloadsource type="full" format="zip">https://github.com/joomla/joomla-cms/releases/download/5.4.7/Joomla_5.4.7-Stable-Update_Package.zip</downloadsource>
-			<downloadsource type="full" format="zip">https://update.joomla.org/releases/5.4.7/Joomla_5.4.7-Stable-Update_Package.zip</downloadsource>
+			<downloadurl type="full" format="zip">https://downloads.joomla.org/cms/joomla5/5-4-8/Joomla_5.4.8-Stable-Update_Package.zip</downloadurl>
+			<downloadsource type="full" format="zip">https://github.com/joomla/joomla-cms/releases/download/5.4.8/Joomla_5.4.8-Stable-Update_Package.zip</downloadsource>
+			<downloadsource type="full" format="zip">https://update.joomla.org/releases/5.4.8/Joomla_5.4.8-Stable-Update_Package.zip</downloadsource>
 		</downloads>
 		<tags>
 			<tag>stable</tag>
 		</tags>
 		<supported_databases mysql="8.0.13" mariadb="10.4" postgresql="12.0" />
 		<php_minimum>8.1.0</php_minimum>
-		<sha256>b2bea5d4a404cf0d48de7b5fa7e9cf7738b8a9af4ae520b8d71685e34bb0ebe0</sha256>
-		<sha384>48b82e68453952bd3f573539e43f94da97fc8554a62c347e0b25a6116606b388c06df24ba8ef461bad413ab8accfea23</sha384>
-		<sha512>e1abbac01fe804d4eb64b1327ace9db4356e39a8782ab547b5257be308ea9215badec27821eae936b9a2db2f120fc175357f54ac3ca5af2313ec2af52eb44223</sha512>
+		<sha256>f6cc93bd182d2f7fa0b6f5994286a0c2aa7cd81d00dfedf8b04ff63fc6af4b5c</sha256>
+		<sha384>1fd28b9a17551827b16ea0da103a3fb1e0c1ec24e6285074520dffb7ce63f76c21b8a42c724f6c5a35e1e602049d083f</sha384>
+		<sha512>d11181d2beb2a407318f746024dabf4696931a9a094d3540d9fb0a24983b9bd1aca6f50053382d1a15e29f28f555fd7e7ce931c1e03cf429378beb1b552992a6</sha512>
 		<maintainer>Joomla! Production Department</maintainer>
 		<maintainerurl>https://www.joomla.org</maintainerurl>
 		<section>STS</section>

--- a/www/core/j5/next.xml
+++ b/www/core/j5/next.xml
@@ -17,9 +17,9 @@
 		</tags>
 		<supported_databases mysql="8.0.13" mariadb="10.4" postgresql="12.0" />
 		<php_minimum>8.1.0</php_minimum>
-		<sha256>f6cc93bd182d2f7fa0b6f5994286a0c2aa7cd81d00dfedf8b04ff63fc6af4b5c</sha256>
-		<sha384>1fd28b9a17551827b16ea0da103a3fb1e0c1ec24e6285074520dffb7ce63f76c21b8a42c724f6c5a35e1e602049d083f</sha384>
-		<sha512>d11181d2beb2a407318f746024dabf4696931a9a094d3540d9fb0a24983b9bd1aca6f50053382d1a15e29f28f555fd7e7ce931c1e03cf429378beb1b552992a6</sha512>
+		<sha256>2c1c4742a9ba5cffb2671e59b6320c26158737a24e169659f706239fadfd2d86</sha256>
+		<sha384>488a6a3fd93d0c6c219dc93b064f2626b201f626c4692062b6b88cc8a19fe7513de595c666eb2618e5e3aaff4107f976</sha384>
+		<sha512>86e9451f94887dbbee1475596fb91d58c2650e12cebfa976d2e0962e94e71d93683b42ce2d911cc9911ea42ca28e9c341dd002ddd8814f41a372e1732a5d0b3e</sha512>
 		<maintainer>Joomla! Production Department</maintainer>
 		<maintainerurl>https://www.joomla.org</maintainerurl>
 		<section>STS</section>

--- a/www/core/j5/next.xml
+++ b/www/core/j5/next.xml
@@ -5,21 +5,21 @@
 		<description>Joomla! 5.4 CMS</description>
 		<element>joomla</element>
 		<type>file</type>
-		<version>5.4.7</version>
-		<infourl title="Joomla 5.4.7 Release">https://www.joomla.org/announcements/release-news/5955-joomla-6-1-2-5-4-7-security-bugfix-release.html</infourl>
+		<version>5.4.8</version>
+		<infourl title="Joomla 5.4.8 Release">https://www.joomla.org/announcements/release-news/5957-joomla-6-1-3-5-4-8-security-bugfix-release.html</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://downloads.joomla.org/cms/joomla5/5-4-7/Joomla_5.4.7-Stable-Update_Package.zip</downloadurl>
-			<downloadsource type="full" format="zip">https://github.com/joomla/joomla-cms/releases/download/5.4.7/Joomla_5.4.7-Stable-Update_Package.zip</downloadsource>
-			<downloadsource type="full" format="zip">https://update.joomla.org/releases/5.4.7/Joomla_5.4.7-Stable-Update_Package.zip</downloadsource>
+			<downloadurl type="full" format="zip">https://downloads.joomla.org/cms/joomla5/5-4-8/Joomla_5.4.8-Stable-Update_Package.zip</downloadurl>
+			<downloadsource type="full" format="zip">https://github.com/joomla/joomla-cms/releases/download/5.4.8/Joomla_5.4.8-Stable-Update_Package.zip</downloadsource>
+			<downloadsource type="full" format="zip">https://update.joomla.org/releases/5.4.8/Joomla_5.4.8-Stable-Update_Package.zip</downloadsource>
 		</downloads>
 		<tags>
 			<tag>stable</tag>
 		</tags>
 		<supported_databases mysql="8.0.13" mariadb="10.4" postgresql="12.0" />
 		<php_minimum>8.1.0</php_minimum>
-		<sha256>b2bea5d4a404cf0d48de7b5fa7e9cf7738b8a9af4ae520b8d71685e34bb0ebe0</sha256>
-		<sha384>48b82e68453952bd3f573539e43f94da97fc8554a62c347e0b25a6116606b388c06df24ba8ef461bad413ab8accfea23</sha384>
-		<sha512>e1abbac01fe804d4eb64b1327ace9db4356e39a8782ab547b5257be308ea9215badec27821eae936b9a2db2f120fc175357f54ac3ca5af2313ec2af52eb44223</sha512>
+		<sha256>f6cc93bd182d2f7fa0b6f5994286a0c2aa7cd81d00dfedf8b04ff63fc6af4b5c</sha256>
+		<sha384>1fd28b9a17551827b16ea0da103a3fb1e0c1ec24e6285074520dffb7ce63f76c21b8a42c724f6c5a35e1e602049d083f</sha384>
+		<sha512>d11181d2beb2a407318f746024dabf4696931a9a094d3540d9fb0a24983b9bd1aca6f50053382d1a15e29f28f555fd7e7ce931c1e03cf429378beb1b552992a6</sha512>
 		<maintainer>Joomla! Production Department</maintainer>
 		<maintainerurl>https://www.joomla.org</maintainerurl>
 		<section>STS</section>

--- a/www/core/list.xml
+++ b/www/core/list.xml
@@ -22,10 +22,10 @@
 	<extension name="Joomla" element="joomla" type="file" version="4.4.14" targetplatformversion="4.2" detailsurl="https://update.joomla.org/core/j4/default.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="4.4.14" targetplatformversion="4.3" detailsurl="https://update.joomla.org/core/j4/default.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="4.4.14" targetplatformversion="4.4" detailsurl="https://update.joomla.org/core/j4/default.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="5.4.7" targetplatformversion="5.0" detailsurl="https://update.joomla.org/core/j5/default.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="5.4.7" targetplatformversion="5.1" detailsurl="https://update.joomla.org/core/j5/default.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="5.4.7" targetplatformversion="5.2" detailsurl="https://update.joomla.org/core/j5/default.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="5.4.7" targetplatformversion="5.3" detailsurl="https://update.joomla.org/core/j5/default.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="5.4.7" targetplatformversion="5.4" detailsurl="https://update.joomla.org/core/j5/default.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.4.8" targetplatformversion="5.0" detailsurl="https://update.joomla.org/core/j5/default.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.4.8" targetplatformversion="5.1" detailsurl="https://update.joomla.org/core/j5/default.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.4.8" targetplatformversion="5.2" detailsurl="https://update.joomla.org/core/j5/default.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.4.8" targetplatformversion="5.3" detailsurl="https://update.joomla.org/core/j5/default.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.4.8" targetplatformversion="5.4" detailsurl="https://update.joomla.org/core/j5/default.xml" />
 </extensionset>
 

--- a/www/core/sts/list_sts.xml
+++ b/www/core/sts/list_sts.xml
@@ -23,11 +23,11 @@
 	<extension name="Joomla" element="joomla" type="file" version="4.4.14" targetplatformversion="4.1" detailsurl="https://update.joomla.org/core/j4/default.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="4.4.14" targetplatformversion="4.2" detailsurl="https://update.joomla.org/core/j4/default.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="4.4.14" targetplatformversion="4.3" detailsurl="https://update.joomla.org/core/j4/default.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="5.4.7" targetplatformversion="4.4.14" detailsurl="https://update.joomla.org/core/j4/next.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.4.8" targetplatformversion="4.4.14" detailsurl="https://update.joomla.org/core/j4/next.xml" />
 	<extension name="Joomla" element="joomla" type="file" version="4.4.14" targetplatformversion="4.4" detailsurl="https://update.joomla.org/core/j4/default.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="5.4.7" targetplatformversion="5.0" detailsurl="https://update.joomla.org/core/j5/next.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="5.4.7" targetplatformversion="5.1" detailsurl="https://update.joomla.org/core/j5/next.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="5.4.7" targetplatformversion="5.2" detailsurl="https://update.joomla.org/core/j5/next.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="5.4.7" targetplatformversion="5.3" detailsurl="https://update.joomla.org/core/j5/next.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="5.4.7" targetplatformversion="5.4" detailsurl="https://update.joomla.org/core/j5/next.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.4.8" targetplatformversion="5.0" detailsurl="https://update.joomla.org/core/j5/next.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.4.8" targetplatformversion="5.1" detailsurl="https://update.joomla.org/core/j5/next.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.4.8" targetplatformversion="5.2" detailsurl="https://update.joomla.org/core/j5/next.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.4.8" targetplatformversion="5.3" detailsurl="https://update.joomla.org/core/j5/next.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="5.4.8" targetplatformversion="5.4" detailsurl="https://update.joomla.org/core/j5/next.xml" />
 </extensionset>


### PR DESCRIPTION
This pull request (PR) has to be merged after the 5.4.8 stable release on Tuesday, August 18, 2026.

It updates the j4 and j5 XML stable update sites to point to that release.

The updates for the nightly build update sites for 5.4.8 and 6.1.3 are made with PR #461 .

I will keep this PR in draft status until that day so it doesn't get merged by mistake.