### PR TITLE
Update nightlies next minor after 6.2.0-beta1

### DIFF
--- a/www/core/nightlies/next_minor_extension.xml
+++ b/www/core/nightlies/next_minor_extension.xml
@@ -5,10 +5,10 @@
 		<description>Joomla! CMS</description>
 		<element>joomla</element>
 		<type>file</type>
-		<version>6.2.0-alpha4-dev</version>
+		<version>6.2.0-beta2-dev</version>
 		<infourl title="Joomla! Nightly Builds">https://developer.joomla.org/nightly-builds.html</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_6.2.0-alpha4-dev-Development-Update_Package.zip</downloadurl>
+			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_6.2.0-beta2-dev-Development-Update_Package.zip</downloadurl>
 		</downloads>
 		<tags>
 			<tag>stable</tag>
@@ -24,10 +24,10 @@
 		<description>Joomla! CMS</description>
 		<element>joomla</element>
 		<type>file</type>
-		<version>6.2.0-alpha4-dev</version>
+		<version>6.2.0-beta2-dev</version>
 		<infourl title="Joomla! Nightly Builds">https://developer.joomla.org/nightly-builds.html</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_6.2.0-alpha4-dev-Development-Update_Package.zip</downloadurl>
+			<downloadurl type="full" format="zip">https://developer.joomla.org/nightlies/Joomla_6.2.0-beta2-dev-Development-Update_Package.zip</downloadurl>
 		</downloads>
 		<tags>
 			<tag>stable</tag>

--- a/www/core/nightlies/next_minor_list.xml
+++ b/www/core/nightlies/next_minor_list.xml
@@ -1,7 +1,7 @@
 <extensionset name="Joomla! Core Nightly Builds" description="Joomla! Core Next Minor Nightly Builds">
-	<extension name="Joomla" element="joomla" type="file" version="6.2.0-alpha4-dev" targetplatformversion="5.4.8" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="6.2.0-alpha4-dev" targetplatformversion="5.4.9" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="6.2.0-alpha4-dev" targetplatformversion="6.0" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="6.2.0-alpha4-dev" targetplatformversion="6.1" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
-	<extension name="Joomla" element="joomla" type="file" version="6.2.0-alpha4-dev" targetplatformversion="6.2" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="6.2.0-beta2-dev" targetplatformversion="5.4.8" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="6.2.0-beta2-dev" targetplatformversion="5.4.9" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="6.2.0-beta2-dev" targetplatformversion="6.0" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="6.2.0-beta2-dev" targetplatformversion="6.1" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
+	<extension name="Joomla" element="joomla" type="file" version="6.2.0-beta2-dev" targetplatformversion="6.2" detailsurl="https://update.joomla.org/core/nightlies/next_minor_extension.xml" />
 </extensionset>


### PR DESCRIPTION
This pull request (PR) has to be merged after the 6.2.0-beta1 release on Tuesday, August 18, 2026.